### PR TITLE
Bump kusk-gateway chart version, fix the labels on the webhook

### DIFF
--- a/charts/kusk-gateway/Chart.yaml
+++ b/charts/kusk-gateway/Chart.yaml
@@ -32,9 +32,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.0.0
+appVersion: "0.0.0-alpha.1"

--- a/charts/kusk-gateway/charts/kusk-gateway-crds/Chart.yaml
+++ b/charts/kusk-gateway/charts/kusk-gateway-crds/Chart.yaml
@@ -25,10 +25,16 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+
+# Note: this subchart can't be installed outside of main chart but we need to keep labels consistent.
+# So make this version to be the same as in main chart.
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.0"
+
+# Note: this subchart can't be installed outside of main chart but we need to keep labels consistent.
+# So make this version to be the same as in main chart.
+appVersion: "0.0.0-alpha.1"

--- a/charts/kusk-gateway/templates/webhooks.yaml
+++ b/charts/kusk-gateway/templates/webhooks.yaml
@@ -59,6 +59,8 @@ metadata:
   creationTimestamp: null
   name: kusk-gateway-validating-webhook-configuration
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kusk-gateway.labels" . | nindent 4 }}
   annotations:
     cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{- include "kusk-gateway.webhooksCertmanagerCertificate" . }}"
 webhooks:


### PR DESCRIPTION
## Pull request description 


Fixes webhook labels.
Bumps to new alpha version.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-