### PR TITLE
Kusk Gateway alpha.2 preparations

### DIFF
--- a/charts/kusk-gateway-envoyfleet/Chart.yaml
+++ b/charts/kusk-gateway-envoyfleet/Chart.yaml
@@ -26,7 +26,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kusk-gateway-envoyfleet/README.md
+++ b/charts/kusk-gateway-envoyfleet/README.md
@@ -14,14 +14,37 @@ After that:
 
 ```sh
 
-helm install kusk-gateway-envoyfleet kubeshop/kusk-gateway-envoyfleet -n kusk-system
+helm install kusk-gateway-envoyfleet kubeshop/kusk-gateway-envoyfleet --namespace kusk-system
 
 ```
+
+You can deploy multiple fleets into any namespace with different names, e.g.
+
+```sh
+
+helm install somename kubeshop/kusk-gateway-envoyfleet --namespace default
+helm install someothername kubeshop/kusk-gateway-envoyfleet --namespace default
+
+```
+
+Please keep the names of Helm releases short as Helm prepends the name of the chart to the name of release and Kubernetes resources created after that will be quite long.
+We recommend to use "kusk-gateway-envoyfleet" (chart name) prefix for the release name to keep your Helm releases organized in that namespace (e.g. "helm install kusk-gateway-envoyfleet-somename --namespace default").
+Helm will create EnvoyFleet CR as "kusk-gateway-envoyfleet-somename" this way.
+
+If you want to override the name for the resources almost completely, install it as:
+
+```sh
+
+helm install kusk-gateway-envoyfleet-somename kubeshop/kusk-gateway-envoyfleet --namespace default --set fullnameOverride=somename
+
+```
+
+This way EnvoyFleet Custom Resource name will be "somename" and it will be more clear and convenient to put it into API/StaticRoute.
 
 ## Deinstallation
 
 ```sh
 
-helm delete kusk-gateway-envoyfleet -n kusk-system
+helm delete kusk-gateway-envoyfleet --namespace kusk-system
 
 ```

--- a/charts/kusk-gateway-envoyfleet/README.md
+++ b/charts/kusk-gateway-envoyfleet/README.md
@@ -4,8 +4,6 @@ This is the Helm chart for [Kusk Gateway](https://github.com/kubeshop/kusk-gatew
 
 It allows you to submit K8S Custom Resourse that is picked up by Kusk Gateway manager, which setups Envoy Fleet with LoadBalancer Service.
 
-Default values for the chart specify its fleet name ("default") and the size (1 instance).
-
 ## Installation
 
 Kusk-gateway main [chart](https://github.com/kubeshop/helm-charts/tree/main/charts/kusk-gateway) must be installed first.
@@ -27,7 +25,7 @@ helm install someothername kubeshop/kusk-gateway-envoyfleet --namespace default
 
 ```
 
-Please keep the names of Helm releases short as Helm prepends the name of the chart to the name of release and Kubernetes resources created after that will be quite long.
+Please keep the names of Helm releases short as Helm prepends the name of the chart to the name of release and Kubernetes resources names created after that will be quite long.
 We recommend to use "kusk-gateway-envoyfleet" (chart name) prefix for the release name to keep your Helm releases organized in that namespace (e.g. "helm install kusk-gateway-envoyfleet-somename --namespace default").
 Helm will create EnvoyFleet CR as "kusk-gateway-envoyfleet-somename" this way.
 

--- a/charts/kusk-gateway-envoyfleet/templates/NOTES.txt
+++ b/charts/kusk-gateway-envoyfleet/templates/NOTES.txt
@@ -1,7 +1,9 @@
-Envoy Fleet installed
+Envoy Fleet was installed.
 
-Get the Fleets Load Balancer External IP address with:
+Get the Fleet's Load Balancer External IP address with:
 
- kubectl get svc -l "app.kubernetes.io/part-of=kusk-gateway,app.kubernetes.io/component=envoy-svc,fleet={{ .Release.Name }}.{{ .Release.Namespace }}" --namespace {{ .Release.Namespace }}
+kubectl get svc -l "app.kubernetes.io/part-of=kusk-gateway,app.kubernetes.io/component=envoy-svc,fleet={{ .Release.Name }}.{{ .Release.Namespace }}" --namespace {{ .Release.Namespace }}
 
-NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+NOTE: It may take a few minutes for the LoadBalancer External IP to be available.
+
+You can use that address to query your deployed endpoints.

--- a/charts/kusk-gateway-envoyfleet/templates/NOTES.txt
+++ b/charts/kusk-gateway-envoyfleet/templates/NOTES.txt
@@ -2,6 +2,6 @@ Envoy Fleet installed
 
 Get the Fleets Load Balancer External IP address with:
 
-   kubectl get svc -l "app=kusk-gateway,component=envoy-svc,fleet={{ .Values.name }}" --namespace {{ .Release.Namespace }}
+ kubectl get svc -l "app.kubernetes.io/part-of=kusk-gateway,app.kubernetes.io/component=envoy-svc,fleet={{ .Release.Name }}.{{ .Release.Namespace }}" --namespace {{ .Release.Namespace }}
 
 NOTE: It may take a few minutes for the LoadBalancer IP to be available.

--- a/charts/kusk-gateway-envoyfleet/templates/envoyFleet.yaml
+++ b/charts/kusk-gateway-envoyfleet/templates/envoyFleet.yaml
@@ -43,5 +43,10 @@ spec:
 {{- end }}
 
 {{- if .Values.terminationGracePeriodSeconds }}
-terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+  terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+{{- end }}
+
+{{- if .Values.tls }}
+  tls:
+{{ toYaml .Values.tls |indent 4 }}
 {{- end }}

--- a/charts/kusk-gateway-envoyfleet/templates/envoyFleet.yaml
+++ b/charts/kusk-gateway-envoyfleet/templates/envoyFleet.yaml
@@ -2,9 +2,46 @@
 apiVersion: gateway.kusk.io/v1alpha1
 kind: EnvoyFleet
 metadata:
-  name: {{ .Values.name }}
+  name: {{ include "kusk-gateway-envoyfleet.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kusk-gateway-envoyfleet.labels" . | nindent 4 }}
 spec:
   size: {{ .Values.size }}
+  image: {{ .Values.image }}
+  service:
+{{ toYaml .Values.service |indent 4 }}
+
+{{- if .Values.resources }}
+  resources:
+{{ toYaml .Values.resources |indent 4 }}
+{{- end -}}
+
+{{- if .Values.annotations }}
+  annotations:
+{{ toYaml .Values.annotations |indent 4 }}
+{{- end -}}
+
+{{- if .Values.nodeSelector }}
+  nodeSelector:
+{{ toYaml .Values.nodeSelector |indent 4 }}
+{{- end -}}
+
+{{- if .Values.tolerations }}
+  tolerations:
+{{ toYaml .Values.tolerations |indent 4 }}
+{{- end -}}
+
+{{- if .Values.affinity }}
+  affinity:
+{{ toYaml .Values.affinity |indent 4 }}
+{{- end -}}
+
+{{- if .Values.accesslog }}
+  accesslog:
+{{ toYaml .Values.accesslog |indent 4 }}
+{{- end }}
+
+{{- if .Values.terminationGracePeriodSeconds }}
+terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+{{- end }}

--- a/charts/kusk-gateway-envoyfleet/values.yaml
+++ b/charts/kusk-gateway-envoyfleet/values.yaml
@@ -126,7 +126,7 @@ accesslog:
   #   duration: "%DURATION%"
 
 # TLS Certificates and Ciphersuites configuration
-tls: []
+tls: {}
 #tls:
   # Optional cipher suites list
   # cipherSuites:

--- a/charts/kusk-gateway-envoyfleet/values.yaml
+++ b/charts/kusk-gateway-envoyfleet/values.yaml
@@ -26,6 +26,9 @@ service:
   # another node, but should have good overall load-spreading.
   # For the preservation of the real client ip in access logs chose "Local"
   # externalTrafficPolicy: Cluster|Local
+
+  # Expose the following ports on the load balancer
+  # By default we serve http and https, both will route to Envoy container "http" listener port.
   ports:
   - name: http
     port: 80
@@ -121,3 +124,20 @@ accesslog:
   #   path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
   #   response_code: "%RESPONSE_CODE%"
   #   duration: "%DURATION%"
+
+# TLS Certificates and Ciphersuites configuration
+tls: []
+#tls:
+  # Optional cipher suites list
+  # cipherSuites:
+  #   - ECDHE-ECDSA-AES128-SHA
+  #   - ECDHE-RSA-AES128-SHA
+  #   - AES128-GCM-SHA256
+  # TLS minimum version to communicate with the client
+  # tlsMinimumProtocolVersion: TLSv1_2
+  # TLS maximum version to communicate with the client
+  # tlsMaximumProtocolVersion: TLSv1_3
+  # The location of k8s secrets with the type tls
+  # tlsSecrets:
+  #   - secretRef: my-tls-secret
+  #     namespace: default

--- a/charts/kusk-gateway-envoyfleet/values.yaml
+++ b/charts/kusk-gateway-envoyfleet/values.yaml
@@ -5,6 +5,109 @@
 nameOverride: ""
 fullnameOverride: ""
 
-# Fleet name, i.e. Fleet ID
-name: default
 size: 1
+
+image: "envoyproxy/envoy-alpine:v1.20.0"
+service:
+  # NodePort, ClusterIP, LoadBalancer
+  type: LoadBalancer
+  # Specify annotations to modify service behaviour, e.g. for GCP to create internal load balancer:
+  # annotations:
+  #   networking.gke.io/load-balancer-type: "Internal"
+  annotations: {}
+  # Specify predefined static load balancer IP address if present, e.g.
+  #loadBalancerIP: 10.10.10.10
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  - name: https
+    port: 443
+    targetPort: http
+
+# Extra annotations on Envoy Proxy pods for, e.g. Prometheus scraping.
+# annotations:
+#   prometheus.io/scrape: 'true'
+#   prometheus.io/port: '9102'
+annotations: {}
+
+###### Envoy Proxy Deployment settings for the pods scheduling #######
+# Read https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/ for the details.
+
+# E.g. schedule Envoy pods to the node with the label "disktype=ssd".
+# nodeSelector:
+#   disktype: "ssd"
+nodeSelector: {}
+
+# Allow to be scheduled on the "tainted" node. E.g. taint with "kubectl taint nodes node1 key1=value1:NoSchedule".
+# Taints will repel the pods from the node unless the pods have the specific toleration.
+# The line below will allow this specific Envoy pod to be scheduled there (but scheduler decideds where to put it anyway).
+# tolerations:
+# - key: "key1"
+#   operator: "Exists"
+#   effect: "NoSchedule"
+tolerations: []
+
+# Provide pods affinity and anti-affinity settings.
+# This is more flexible than nodeSelector scheme but they can be specified together.
+# For the scalability and fault tolerance we prefer to put all Envoy pods onto different nodes - in a case one node fails we survive on others.
+# The block below will search for all Envoy Fleet pods with matching labels (here - "fleet" label with Envoy Fleet name.namespace as value) and will try to schedule pods
+# on different nodes.
+# Other fleets (if present) are not taken into consideration. You can specify nodeAffinity and podAffinity as well.
+# Note that pods labels are defined by Kusk Gateway Manager using the deployed name and namespace of EnvoyFleet Custom Resource.
+# affinity:
+#   podAntiAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#     - labelSelector:
+#         matchExpressions:
+#         - key: app.kubernetes.io/name
+#           operator: In
+#           values:
+#           - kusk-gateway-envoy-fleet
+#         - key: fleet
+#           operator: In
+#           values: "default.default"
+#       topologyKey: kubernetes.io/hostname
+affinity: {}
+
+# CPU and memory requests and limits for Envoy Proxy container
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# Graceful termination time for Envoy pods
+# terminationGracePeriodSeconds: 5
+
+# Access logging to stdout
+# If missing - disable access logging to stdout
+accesslog:
+  # json|text
+  format: text
+
+  # Depending on format we can specify our own log template or if template is not specified - default Kusk Gateway will be used
+  # Below are specified the examples of similar and minimalistic formats for both text and json format types.
+  # Text format fields order is preserved.
+  # The output example:
+  # "[2021-12-15T16:50:50.217Z]" "GET" "/" "200" "1"
+
+  # text_template: |
+  #   "[%START_TIME%]" "%REQ(:METHOD)%" "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%" "%RESPONSE_CODE%" "%DURATION%"
+  #
+  # Json format fields order isn't preserved
+  # The output example:
+  # {"start_time":"2021-12-15T16:46:52.135Z","path":"/","response_code":200,"method":"GET","duration":1}
+
+  # json_template:
+  #   start_time: "%START_TIME%"
+  #   method: "%REQ(:METHOD)%"
+  #   path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+  #   response_code: "%RESPONSE_CODE%"
+  #   duration: "%DURATION%"

--- a/charts/kusk-gateway-envoyfleet/values.yaml
+++ b/charts/kusk-gateway-envoyfleet/values.yaml
@@ -36,8 +36,9 @@ service:
 
 # Extra annotations on Envoy Proxy pods for, e.g. Prometheus scraping.
 # annotations:
-#   prometheus.io/scrape: 'true'
-#   prometheus.io/port: '9102'
+  #   prometheus.io/scrape: 'true'
+  #   prometheus.io/port: '19000'
+  #   prometheus.io/path: /stats/prometheus
 annotations: {}
 
 ###### Envoy Proxy Deployment settings for the pods scheduling #######

--- a/charts/kusk-gateway-envoyfleet/values.yaml
+++ b/charts/kusk-gateway-envoyfleet/values.yaml
@@ -17,6 +17,15 @@ service:
   annotations: {}
   # Specify predefined static load balancer IP address if present, e.g.
   #loadBalancerIP: 10.10.10.10
+
+  # externalTrafficPolicy denotes if this Service desires to route external
+  # traffic to node-local or cluster-wide endpoints. "Local" preserves the
+  # client source IP and avoids a second hop for LoadBalancer and Nodeport
+  # type services, but risks potentially imbalanced traffic spreading.
+  # "Cluster" obscures the client source IP and may cause a second hop to
+  # another node, but should have good overall load-spreading.
+  # For the preservation of the real client ip in access logs chose "Local"
+  # externalTrafficPolicy: Cluster|Local
   ports:
   - name: http
     port: 80

--- a/charts/kusk-gateway/Chart.yaml
+++ b/charts/kusk-gateway/Chart.yaml
@@ -32,9 +32,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.5
+version: 0.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "v0.0.0-alpha.1"
+appVersion: "v0.0.0-alpha.2"

--- a/charts/kusk-gateway/charts/kusk-gateway-crds/templates/gateway.kusk.io_apis.yaml
+++ b/charts/kusk-gateway/charts/kusk-gateway-crds/templates/gateway.kusk.io_apis.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.7.0
     cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{- include "kusk-gateway.webhooksCertmanagerCertificate" . }}"
   creationTimestamp: null
   labels:
@@ -49,8 +49,27 @@ spec:
           spec:
             description: APISpec defines the desired state of API
             properties:
+              fleet:
+                description: Fleet represents EnvoyFleet ID, which is deployed EnvoyFleet
+                  CustomResource name and namespace Optional, if missing will be automatically
+                  added by the Kusk Gateway with the discovery of the single fleet
+                  in the cluster (MutatingWebhookConfiguration for the API resource
+                  must be enabled).
+                properties:
+                  name:
+                    description: deployed Envoy Fleet CR name
+                    pattern: ^[a-z0-9-]{1,62}$
+                    type: string
+                  namespace:
+                    description: deployed Envoy Fleet CR namespace
+                    pattern: ^[a-z0-9-]{1,62}$
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
               spec:
-                description: Spec represents OpenAPI spec
+                description: Spec represents OpenAPI spec as an embedded string.
                 type: string
             required:
             - spec

--- a/charts/kusk-gateway/charts/kusk-gateway-crds/templates/gateway.kusk.io_envoyfleet.yaml
+++ b/charts/kusk-gateway/charts/kusk-gateway-crds/templates/gateway.kusk.io_envoyfleet.yaml
@@ -954,6 +954,19 @@ spec:
                       type: string
                     description: Service's annotations
                     type: object
+                  externalTrafficPolicy:
+                    description: externalTrafficPolicy denotes if this Service desires
+                      to route external traffic to node-local or cluster-wide endpoints.
+                      "Local" preserves the client source IP and avoids a second hop
+                      for LoadBalancer and Nodeport type services, but risks potentially
+                      imbalanced traffic spreading. "Cluster" obscures the client
+                      source IP and may cause a second hop to another node, but should
+                      have good overall load-spreading. For the preservation of the
+                      real client ip in access logs chose "Local"
+                    enum:
+                    - Cluster
+                    - Local
+                    type: string
                   loadBalancerIP:
                     description: Static ip address for the LoadBalancer type if available
                     type: string
@@ -1048,6 +1061,50 @@ spec:
                   cleanup time for your process. Defaults to 30 seconds.
                 format: int64
                 type: integer
+              tls:
+                description: TLS configuration
+                properties:
+                  cipherSuites:
+                    description: 'If specified, the TLS listener will only support
+                      the specified cipher list when negotiating TLS 1.0-1.2 (this
+                      setting has no effect when negotiating TLS 1.3). If not specified,
+                      a default list will be used. Defaults are different for server
+                      (downstream) and client (upstream) TLS configurations. For more
+                      information see: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto'
+                    items:
+                      type: string
+                    type: array
+                  tlsMaximumProtocolVersion:
+                    description: Maximum TLS protocol version. By default, it’s TLSv1_2
+                      for clients and TLSv1_3 for servers.
+                    type: string
+                  tlsMinimumProtocolVersion:
+                    description: Minimum TLS protocol version. By default, it’s TLSv1_2
+                      for clients and TLSv1_0 for servers.
+                    type: string
+                  tlsSecrets:
+                    description: 'SecretName and Namespace combinations for locating
+                      TLS secrets containing TLS certificates You can specify more
+                      than one For more information on how certificate selection works
+                      see: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/ssl#certificate-selection'
+                    items:
+                      properties:
+                        namespace:
+                          description: Namespace where the Kubernetes certificate
+                            resides
+                          type: string
+                        secretRef:
+                          description: Name of the Kubernetes secret containing the
+                            TLS certificate
+                          type: string
+                      required:
+                      - namespace
+                      - secretRef
+                      type: object
+                    type: array
+                required:
+                - tlsSecrets
+                type: object
               tolerations:
                 description: Tolerations allow pod to be scheduled to the nodes that
                   has specific toleration labels, optional

--- a/charts/kusk-gateway/charts/kusk-gateway-crds/templates/gateway.kusk.io_envoyfleet.yaml
+++ b/charts/kusk-gateway/charts/kusk-gateway-crds/templates/gateway.kusk.io_envoyfleet.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.7.0
     cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{- include "kusk-gateway.webhooksCertmanagerCertificate" . }}"
   creationTimestamp: null
   labels:
@@ -53,6 +53,982 @@ spec:
           spec:
             description: EnvoyFleetSpec defines the desired state of EnvoyFleet
             properties:
+              accesslog:
+                description: Access logging settings for the Envoy
+                properties:
+                  format:
+                    description: Stdout logging format - text for unstructured and
+                      json for the structured type of logging
+                    enum:
+                    - json
+                    - text
+                    type: string
+                  json_template:
+                    additionalProperties:
+                      type: string
+                    description: Logging format template for the structured json type.
+                      See https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage
+                      for the usage. Uses Kusk Gateway defaults if not specified.
+                    type: object
+                  text_template:
+                    description: Logging format template for the unstructured text
+                      type. See https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage
+                      for the usage. Uses Kusk Gateway defaults if not specified.
+                    type: string
+                required:
+                - format
+                type: object
+              affinity:
+                description: Affinity is used to schedule Envoy pod(s) to specific
+                  nodes, optional
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is beta-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                                This field is beta-level and is only honored when
+                                PodAffinityNamespaceSelector feature is enabled.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is beta-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                                This field is beta-level and is only honored when
+                                PodAffinityNamespaceSelector feature is enabled.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              annotations:
+                additionalProperties:
+                  type: string
+                description: Additional Envoy Deployment annotations, optional
+                type: object
+              image:
+                description: Envoy image tag
+                type: string
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: 'Node Selector is used to schedule the Envoy pod(s) to
+                  the specificly labeled nodes, optional This is the map of "key:
+                  value" labels (e.g. "disktype": "ssd")'
+                type: object
+              resources:
+                description: Resources allow to set CPU and Memory resource requests
+                  and limits, optional
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              service:
+                description: Service describes Envoy K8s service settings
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Service's annotations
+                    type: object
+                  loadBalancerIP:
+                    description: Static ip address for the LoadBalancer type if available
+                    type: string
+                  ports:
+                    description: Kubernetes Service ports
+                    items:
+                      description: ServicePort contains information on service's port.
+                      properties:
+                        appProtocol:
+                          description: The application protocol for this port. This
+                            field follows standard Kubernetes label syntax. Un-prefixed
+                            names are reserved for IANA standard service names (as
+                            per RFC-6335 and http://www.iana.org/assignments/service-names).
+                            Non-standard protocols should use prefixed names such
+                            as mycompany.com/my-custom-protocol.
+                          type: string
+                        name:
+                          description: The name of this port within the service. This
+                            must be a DNS_LABEL. All ports within a ServiceSpec must
+                            have unique names. When considering the endpoints for
+                            a Service, this must match the 'name' field in the EndpointPort.
+                            Optional if only one ServicePort is defined on this service.
+                          type: string
+                        nodePort:
+                          description: 'The port on each node on which this service
+                            is exposed when type is NodePort or LoadBalancer.  Usually
+                            assigned by the system. If a value is specified, in-range,
+                            and not in use it will be used, otherwise the operation
+                            will fail.  If not specified, a port will be allocated
+                            if this Service requires one.  If this field is specified
+                            when creating a Service which does not need it, creation
+                            will fail. This field will be wiped when updating a Service
+                            to no longer need it (e.g. changing type from NodePort
+                            to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                          format: int32
+                          type: integer
+                        port:
+                          description: The port that will be exposed by this service.
+                          format: int32
+                          type: integer
+                        protocol:
+                          default: TCP
+                          description: The IP protocol for this port. Supports "TCP",
+                            "UDP", and "SCTP". Default is TCP.
+                          type: string
+                        targetPort:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'Number or name of the port to access on the
+                            pods targeted by the service. Number must be in the range
+                            1 to 65535. Name must be an IANA_SVC_NAME. If this is
+                            a string, it will be looked up as a named port in the
+                            target Pod''s container ports. If this is not specified,
+                            the value of the ''port'' field is used (an identity map).
+                            This field is ignored for services with clusterIP=None,
+                            and should be omitted or set equal to the ''port'' field.
+                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    type: array
+                  type:
+                    description: 'Kubernetes service type: NodePort, ClusterIP or
+                      LoadBalancer'
+                    enum:
+                    - NodePort
+                    - ClusterIP
+                    - LoadBalancer
+                    type: string
+                required:
+                - ports
+                - type
+                type: object
               size:
                 default: 1
                 description: Size field specifies the number of Envoy Pods being deployed.
@@ -60,9 +1036,69 @@ spec:
                 format: int32
                 minimum: 1
                 type: integer
+              terminationGracePeriodSeconds:
+                description: Optional duration in seconds the pod needs to terminate
+                  gracefully. May be decreased in delete request. Value must be non-negative
+                  integer. The value zero indicates stop immediately via the kill
+                  signal (no opportunity to shut down). If this value is nil, the
+                  default grace period will be used instead. The grace period is the
+                  duration in seconds after the processes running in the pod are sent
+                  a termination signal and the time when the processes are forcibly
+                  halted with a kill signal. Set this value longer than the expected
+                  cleanup time for your process. Defaults to 30 seconds.
+                format: int64
+                type: integer
+              tolerations:
+                description: Tolerations allow pod to be scheduled to the nodes that
+                  has specific toleration labels, optional
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+            required:
+            - image
+            - service
             type: object
           status:
             description: EnvoyFleetStatus defines the observed state of EnvoyFleet
+            properties:
+              state:
+                description: State indicates Envoy Fleet state
+                type: string
             type: object
         required:
         - spec

--- a/charts/kusk-gateway/charts/kusk-gateway-crds/templates/gateway.kusk.io_staticroutes.yaml
+++ b/charts/kusk-gateway/charts/kusk-gateway-crds/templates/gateway.kusk.io_staticroutes.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.7.0
     cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{- include "kusk-gateway.webhooksCertmanagerCertificate" . }}"
   creationTimestamp: null
   labels:
@@ -49,6 +49,25 @@ spec:
           spec:
             description: StaticRouteSpec defines the desired state of StaticRoute
             properties:
+              fleet:
+                description: Fleet represents EnvoyFleet ID, which is deployed EnvoyFleet
+                  CustomResource name and namespace Optional, if missing will be automatically
+                  added by the Kusk Gateway with the discovery of the single fleet
+                  in the cluster (MutatingWebhookConfiguration for the API resource
+                  must be enabled).
+                properties:
+                  name:
+                    description: deployed Envoy Fleet CR name
+                    pattern: ^[a-z0-9-]{1,62}$
+                    type: string
+                  namespace:
+                    description: deployed Envoy Fleet CR namespace
+                    pattern: ^[a-z0-9-]{1,62}$
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
               hosts:
                 description: Hosts is a collection of vhosts the rules apply to. Defaults
                   to "*" - vhost that matches all domain names.
@@ -131,10 +150,11 @@ spec:
                                 description: Rewrite is the pattern (regex) and a
                                   substitution string that will change URL when request
                                   is being forwarded to the upstream service. e.g.
-                                  given that Base is set to "/petstore/api/v3", and
-                                  with Rewrite.Pattern is set to "^/petstore", Rewrite.Substitution
-                                  is set to "" path that would be generated is "/petstore/api/v3/pets",
-                                  URL that the upstream service would receive is "/api/v3/pets".
+                                  given that Prefix is set to "/petstore/api/v3",
+                                  and with Rewrite.Pattern is set to "^/petstore",
+                                  Rewrite.Substitution is set to "" path that would
+                                  be generated is "/petstore/api/v3/pets", URL that
+                                  the upstream service would receive is "/api/v3/pets".
                                 properties:
                                   pattern:
                                     type: string

--- a/charts/kusk-gateway/templates/NOTES.txt
+++ b/charts/kusk-gateway/templates/NOTES.txt
@@ -1,0 +1,3 @@
+Kusk Gateway Manager was succesfully deployed.
+
+Deploy Envoy Fleet Helm chart to create the gateway and then deploy API or StaticRoute custom resources to expose your applications endpoints.

--- a/charts/kusk-gateway/templates/certmanagement.yaml
+++ b/charts/kusk-gateway/templates/certmanagement.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.webhooks.enabled -}}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -21,5 +20,3 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
-
-{{- end -}}

--- a/charts/kusk-gateway/templates/deployment.yaml
+++ b/charts/kusk-gateway/templates/deployment.yaml
@@ -60,6 +60,9 @@ spec:
             - name: xds
               containerPort: 18000
               protocol: TCP
+            - containerPort: 17000
+              name: validator
+              protocol: TCP
             - containerPort: 9443
               name: webhook-server
               protocol: TCP

--- a/charts/kusk-gateway/templates/roles.yaml
+++ b/charts/kusk-gateway/templates/roles.yaml
@@ -221,6 +221,15 @@ metadata:
     {{- include "kusk-gateway.labels" . | nindent 4 }}
 rules:
 - apiGroups:
+  - ""
+  - v1
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - gateway.kusk.io
   resources:
   - apis

--- a/charts/kusk-gateway/templates/service.yaml
+++ b/charts/kusk-gateway/templates/service.yaml
@@ -16,7 +16,24 @@ spec:
       name: xds
   selector:
     {{- include "kusk-gateway.selectorLabels" . | nindent 4 }}
-
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "kusk-gateway-validator-service"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kusk-gateway.labels" . | nindent 4 }}
+    app.kubernetes.io/component: validator-service
+spec:
+  type: {{ .Values.validatorService.type }}
+  ports:
+    - port: {{ .Values.validatorService.port }}
+      targetPort: validator
+      protocol: TCP
+      name: validator
+  selector:
+    {{- include "kusk-gateway.selectorLabels" . | nindent 4 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/kusk-gateway/templates/service.yaml
+++ b/charts/kusk-gateway/templates/service.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  # FIXME: this name is currently harcoded in manager
-  name: kusk-xds-service
+  name: kusk-gateway-xds-service
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kusk-gateway.labels" . | nindent 4 }}
+    app.kubernetes.io/component: xds-service
 spec:
   type: {{ .Values.xdsService.type }}
   ports:
@@ -17,7 +17,6 @@ spec:
   selector:
     {{- include "kusk-gateway.selectorLabels" . | nindent 4 }}
 
-{{ if .Values.webhooks.enabled -}}
 ---
 apiVersion: v1
 kind: Service
@@ -35,5 +34,3 @@ spec:
       name: webhook-server
   selector:
     {{- include "kusk-gateway.selectorLabels" . | nindent 4 }}
-
-{{- end -}}

--- a/charts/kusk-gateway/templates/webhooks.yaml
+++ b/charts/kusk-gateway/templates/webhooks.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.webhooks.enabled -}}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -105,6 +104,3 @@ webhooks:
     resources:
     - staticroutes
   sideEffects: None
-
-
-{{- end -}}

--- a/charts/kusk-gateway/values.yaml
+++ b/charts/kusk-gateway/values.yaml
@@ -43,6 +43,10 @@ xdsService:
   type: ClusterIP
   port: 18000
 
+validatorService:
+  type: ClusterIP
+  port: 17000
+
 webhooks:
   certsDir: "/tmp/k8s-webhook-server/serving-certs"
   # failurePolicy of the webhook, Fail or Ignore

--- a/charts/kusk-gateway/values.yaml
+++ b/charts/kusk-gateway/values.yaml
@@ -44,7 +44,6 @@ xdsService:
   port: 18000
 
 webhooks:
-  enabled: true
   certsDir: "/tmp/k8s-webhook-server/serving-certs"
   # failurePolicy of the webhook, Fail or Ignore
   failurePolicy: Fail


### PR DESCRIPTION
## Pull request description 

Changes kusk-gateway-manager and kusk-gateway-envoyfleet charts for the upcoming alpha.2 version.

Webhooks are now mandatory since we depend a lot on them.

More documentation.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-