### PR TITLE
Add log level and development mode options to manager args

### DIFF
--- a/charts/kusk-gateway/values.yaml
+++ b/charts/kusk-gateway/values.yaml
@@ -85,6 +85,13 @@ manager:
     - --health-probe-bind-address=:8081
     - --metrics-bind-address=127.0.0.1:8080
     - --envoy-control-plane-bind-address=:18000
+
+    # Configure log verbocity
+    # Available levels [DEBUG|INFO|WARN|ERROR|DPANIC|PANIC|FATAL]
+    # - --log-level=INFO
+    # Enable development mode - logs out stack traces on warn logs and panics on dpanic level logs
+    # - --development=true
+
     # To login to the shell (if it is present in container) and run commands manually
     # command:
     #   - "tail"


### PR DESCRIPTION
## Pull request description 
Add log level option to kusk-gateway manager args which allows user to set log verbocity.

Add Development boolean option which allows kusk-gateway manager to be run in development mode (logging stack traces on warning logs and panicking on dpanic level logs

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-