### PR TITLE
fix: allow only GET for api ingress and POST to run tests and test suites

### DIFF
--- a/charts/testkube/values-dashboard.yaml
+++ b/charts/testkube/values-dashboard.yaml
@@ -132,6 +132,16 @@ testkube-api:
       # controls whether the ingress is modified ‘in-place’,
       # or a new one is created specifically for the HTTP01 challenge.
       acme.cert-manager.io/http01-edit-in-place: "true"
+      nginx.ingress.kubernetes.io/server-snippet: |
+      set $gethttpmethod 0;
+
+      if ( $request_method = GET ){
+        set $gethttpmethod 1;
+      }
+
+      if ( $gethttpmethod != 1 ) {
+        return 401;
+      }
     path: /results/(v\d/.*)
     hosts:
       - dashboard.testkube.io

--- a/charts/testkube/values-dashboard.yaml
+++ b/charts/testkube/values-dashboard.yaml
@@ -133,15 +133,15 @@ testkube-api:
       # or a new one is created specifically for the HTTP01 challenge.
       acme.cert-manager.io/http01-edit-in-place: "true"
       nginx.ingress.kubernetes.io/server-snippet: |
-      set $gethttpmethod 0;
+        set $gethttpmethod 0;
 
-      if ( $request_method = GET ){
-        set $gethttpmethod 1;
-      }
+        if ( $request_method = GET ){
+          set $gethttpmethod 1;
+        }
 
-      if ( $gethttpmethod != 1 ) {
-        return 401;
-      }
+        if ( $gethttpmethod != 1 ) {
+          return 401;
+        }
     path: /results/(v\d/.*)
     hosts:
       - dashboard.testkube.io

--- a/charts/testkube/values-dashboard.yaml
+++ b/charts/testkube/values-dashboard.yaml
@@ -133,13 +133,28 @@ testkube-api:
       # or a new one is created specifically for the HTTP01 challenge.
       acme.cert-manager.io/http01-edit-in-place: "true"
       nginx.ingress.kubernetes.io/server-snippet: |
-        set $gethttpmethod 0;
+        set $methodallowed "";
+        set $pathallowed "";
 
         if ( $request_method = GET ){
-          set $gethttpmethod 1;
+          set $methodallowed "true";
+          set $pathallowed "true";
         }
 
-        if ( $gethttpmethod != 1 ) {
+        if ( $request_method = POST ){
+          set $methodallowed "true";
+        }      
+
+        if ( $uri ~ "^(.*)/tests/(.*)/executions$" ){
+          set $pathallowed "true";
+        }  
+
+        if ( $uri ~ "^(.*)/test-suites/(.*)/executions$" ){
+          set $pathallowed "true";
+        }
+
+        set $condition "$methodallowed+$pathallowed";
+        if ( $condition != "true+true" ) {
           return 401;
         }
     path: /results/(v\d/.*)

--- a/charts/testkube/values-demo.yaml
+++ b/charts/testkube/values-demo.yaml
@@ -133,13 +133,28 @@ testkube-api:
       # or a new one is created specifically for the HTTP01 challenge.
       # acme.cert-manager.io/http01-edit-in-place: "true"
       nginx.ingress.kubernetes.io/server-snippet: |
-        set $gethttpmethod 0;
+        set $methodallowed "";
+        set $pathallowed "";
 
         if ( $request_method = GET ){
-          set $gethttpmethod 1;
+          set $methodallowed "true";
+          set $pathallowed "true";
         }
 
-        if ( $gethttpmethod != 1 ) {
+        if ( $request_method = POST ){
+          set $methodallowed "true";
+        }      
+
+        if ( $uri ~ "^(.*)/tests/(.*)/executions$" ){
+          set $pathallowed "true";
+        }  
+
+        if ( $uri ~ "^(.*)/test-suites/(.*)/executions$" ){
+          set $pathallowed "true";
+        }
+
+        set $condition "$methodallowed+$pathallowed";
+        if ( $condition != "true+true" ) {
           return 401;
         }
     path: /results/(v\d/.*)

--- a/charts/testkube/values-demo.yaml
+++ b/charts/testkube/values-demo.yaml
@@ -133,15 +133,15 @@ testkube-api:
       # or a new one is created specifically for the HTTP01 challenge.
       # acme.cert-manager.io/http01-edit-in-place: "true"
       nginx.ingress.kubernetes.io/server-snippet: |
-      set $gethttpmethod 0;
+        set $gethttpmethod 0;
 
-      if ( $request_method = GET ){
-        set $gethttpmethod 1;
-      }
+        if ( $request_method = GET ){
+          set $gethttpmethod 1;
+        }
 
-      if ( $gethttpmethod != 1 ) {
-        return 401;
-      }
+        if ( $gethttpmethod != 1 ) {
+          return 401;
+        }
     path: /results/(v\d/.*)
     hosts:
       - demo.testkube.io

--- a/charts/testkube/values-demo.yaml
+++ b/charts/testkube/values-demo.yaml
@@ -132,6 +132,16 @@ testkube-api:
       # controls whether the ingress is modified ‘in-place’,
       # or a new one is created specifically for the HTTP01 challenge.
       # acme.cert-manager.io/http01-edit-in-place: "true"
+      nginx.ingress.kubernetes.io/server-snippet: |
+      set $gethttpmethod 0;
+
+      if ( $request_method = GET ){
+        set $gethttpmethod 1;
+      }
+
+      if ( $gethttpmethod != 1 ) {
+        return 401;
+      }
     path: /results/(v\d/.*)
     hosts:
       - demo.testkube.io


### PR DESCRIPTION
## Pull request description 

Allow only GET for api ingress and POST to run tests and test suites

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-