### PR TITLE
Update CODEOWNERS: remove Taras and add kylehodgetts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@ img/* @olensmar
 api/* @olensmar 
 api/v1/* @olensmar 
 
-* @exu @nicufk @jasmingacic @fog1985 @vsukhin
+* @exu @nicufk @jasmingacic @kylehodgetts @vsukhin


### PR DESCRIPTION
Taras' username in the CODEOWNERS file caused Github to complain as he is not part of the org anymore.
Also added myself as a code owner