### PR TITLE
 feat: Add optional serviceAccountName

### DIFF
--- a/charts/testkube-api/templates/minio.yaml
+++ b/charts/testkube-api/templates/minio.yaml
@@ -89,6 +89,9 @@ spec:
             port: 9000
           initialDelaySeconds: 120
           periodSeconds: 20
+      {{- if  .Values.minio.serviceAccountName }}
+      serviceAccountName: {{ .Values.minio.serviceAccountName }}
+      {{- end }}
       {{- with .Values.minio.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -56,6 +56,7 @@ minio:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  serviceAccountName: ""
 
 ingress:
   enabled: false


### PR DESCRIPTION
## Pull request description 

Adding optional serviceAccountName. This allows for minio not to use default serviceAccount, necessary for implementations with restrictions by default (PSP, etc)

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-