### PR TITLE
Grant RBAC create API permission to Kusk Gateway API clusterrole

### DIFF
--- a/charts/kusk-gateway-api/templates/clusterrole.yaml
+++ b/charts/kusk-gateway-api/templates/clusterrole.yaml
@@ -8,6 +8,7 @@ rules:
   resources:
   - apis
   verbs:
+  - create
   - get
   - list
   - watch


### PR DESCRIPTION
## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

- grant create permission on API resources to kusk gateway api clusterrole

## Fixes

- Permission denied when trying to publish an API via the kusk gateway API