### PR TITLE
feat: add version as env variable

### DIFF
--- a/charts/tracetest/templates/deployment.yaml
+++ b/charts/tracetest/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: VERSION
+              value: {{ .Chart.AppVersion }}
           volumeMounts:
           - name: config
             mountPath: /app/config


### PR DESCRIPTION
## Pull request description 
Tracetest: This adds an env variable `VERSION`. By default, its value is the docker image tag.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-