### PR TITLE
Quote config map values

### DIFF
--- a/charts/kusk-gateway/templates/configmap.yaml
+++ b/charts/kusk-gateway/templates/configmap.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 data:
-  AGENT_MANAGER_BIND_ADDR: :{{ .Values.agentService.port }}
+  AGENT_MANAGER_BIND_ADDR: ":{{ .Values.agentService.port }}"
   ENABLE_LEADER_ELECTION: "{{ .Values.manager.enableLeaderElection }}"
-  ENVOY_CONTROL_PLANE_BIND_ADDR: :{{ .Values.xdsService.port }}
-  HEALTH_PROBE_BIND_ADDR: :{{ .Values.manager.health.liveness.port }}
-  LOG_LEVEL: {{ .Values.manager.logLevel }}
-  METRICS_BIND_ADDR: {{ .Values.manager.metrics.bindAddress }}
-  WEBHOOK_CERTS_DIR: {{ .Values.webhooks.certsDir }}
-  ANALYTICS_ENABLED: {{ .Values.analytics.enabled }}
+  ENVOY_CONTROL_PLANE_BIND_ADDR: ":{{ .Values.xdsService.port }}"
+  HEALTH_PROBE_BIND_ADDR: ":{{ .Values.manager.health.liveness.port }}"
+  LOG_LEVEL: "{{ .Values.manager.logLevel }}"
+  METRICS_BIND_ADDR: "{{ .Values.manager.metrics.bindAddress }}"
+  WEBHOOK_CERTS_DIR: "{{ .Values.webhooks.certsDir }}"
+  ANALYTICS_ENABLED: "{{ .Values.analytics.enabled }}"
 kind: ConfigMap
 metadata:
   name: kusk-gateway-manager


### PR DESCRIPTION
Fix error

```
Error: ConfigMap in version "v1" cannot be handled as a ConfigMap: v1.ConfigMap.Data: ReadString: expects " or n, but found f, error found in #10 byte of ...|ENABLED":false,"ENAB|..., bigger context ...|_MANAGER_BIND_ADDR":":18010","ANALYTICS_ENABLED":false,"ENABLE_LEADER_ELECTION":"false","ENVOY_CONTR|...
```

Boolean for enabling analytics should be passed as a string

related https://github.com/hashicorp/terraform-provider-helm/issues/556#issuecomment-665620365