### PR TITLE
Rename annotation to `gateway.kusk.io`

### DIFF
--- a/charts/kusk-gateway-api/templates/service.yaml
+++ b/charts/kusk-gateway-api/templates/service.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: {{ include "kusk-gateway-api.fullname" . }}
   annotations:
-    kusk-gateway/openapi-url: https://raw.githubusercontent.com/kubeshop/kuskgateway-api-server/{{ .Values.image.tag | default .Chart.AppVersion }}/api/openapi.yaml
-    kusk-gateway/path-prefix: /api
-    kusk-gateway/path-prefix-substitution: ""
-    kusk-gateway/envoy-fleet: {{ .Values.envoyfleet.name }}.{{ .Values.envoyfleet.namespace }}
+    gateway.kusk.io/openapi-url: https://raw.githubusercontent.com/kubeshop/kuskgateway-api-server/{{ .Values.image.tag | default .Chart.AppVersion }}/api/openapi.yaml
+    gateway.kusk.io/path-prefix: /api
+    gateway.kusk.io/path-prefix-substitution: ""
+    gateway.kusk.io/envoy-fleet: {{ .Values.envoyfleet.name }}.{{ .Values.envoyfleet.namespace }}
     {{- include "kusk-gateway-api.labels" . | nindent 4 }} 
   labels:
     {{- include "kusk-gateway-api.labels" . | nindent 4 }}


### PR DESCRIPTION
Use public Kubernetes annotations by having keys, e.g., (`gateway.kusk.io`), that contain periods.

Partially closes kubeshop/kusk#49.

See <https://github.com/kubeshop/kusk/issues/49>

Signed-off-by: Mohamed Bana <mohamed@bana.io>

---

**Note:** Please do not merge until the corresponding change has been made in <https://github.com/kubeshop/kusk-gateway/blob/main/internal/controllers/service_controller.go#L62>.

---

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-