### PR TITLE
Allow kusk gateway manager to get list and watch namespaces

### DIFF
--- a/charts/kusk-gateway/templates/roles.yaml
+++ b/charts/kusk-gateway/templates/roles.yaml
@@ -225,6 +225,7 @@ rules:
   - v1
   resources:
   - secrets
+  - namespaces
   verbs:
   - get
   - list


### PR DESCRIPTION
## Pull request description 

To create a unique id for telemetry, part of this id comes from the uid of the namespace in which kusk gateway is deployed.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

- Add permissions for kgw manager to get list and watch namespaces

## Fixes

-