### PR TITLE
update policy to allow both plaintext or mTLS tunnel

### DIFF
--- a/charts/testkube-api/templates/peerauthentication.yaml
+++ b/charts/testkube-api/templates/peerauthentication.yaml
@@ -5,9 +5,6 @@ metadata:
   name: {{ include "testkube-api.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  selector:
-    matchLabels:
-      {{- include "testkube-api.selectorLabels" . | nindent 6 }}
   mtls:
     mode: PERMISSIVE
 {{ end -}}


### PR DESCRIPTION
## Pull request description 
Updated `PeerAuthentication` policy to allow either plaintext or mTLS tunnel for the whole `testkube` namespace


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-