### PR TITLE
add dashboard host to testkube cluster

### DIFF
--- a/charts/testkube/values-demo.yaml
+++ b/charts/testkube/values-demo.yaml
@@ -246,10 +246,12 @@ testkube-dashboard:
     path: /
     hosts:
       - demo.testkube.io
+      - dashboard.testkube.io
     tlsenabled: "true"
     tls: # < placing a host in the TLS config will indicate a certificate should be created
       - hosts:
           - demo.testkube.io
+          - dashboard.testkube.io
         secretName: testkube-demo-cert-secret
   apiServerEndpoint: "demo.testkube.io/results" #get the address of the endpoint or set it using helm
   oauth2:


### PR DESCRIPTION
## Pull request description 
Pointed dashboard.testkube.io to `testkube-dev` cluster
https://dashboard.testkube.io/

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-