### PR TITLE
Kusk Gateway: Add Default field to EnvoyFleet CRD

### DIFF
--- a/charts/kusk-gateway-api/Chart.yaml
+++ b/charts/kusk-gateway-api/Chart.yaml
@@ -17,6 +17,6 @@ keywords:
 
 type: application
 
-version: 0.1.6
+version: 0.1.7
 
 appVersion: "v1.1.1"

--- a/charts/kusk-gateway-api/templates/deployment.yaml
+++ b/charts/kusk-gateway-api/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: "ANALYTICS_ENABLED"
+            value: "{{ .Values.enabled }}"
           ports:
             - name: http
               containerPort: 8080

--- a/charts/kusk-gateway-api/values.yaml
+++ b/charts/kusk-gateway-api/values.yaml
@@ -64,3 +64,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+analytics:
+  enabled: true

--- a/charts/kusk-gateway/Chart.yaml
+++ b/charts/kusk-gateway/Chart.yaml
@@ -26,7 +26,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.32
+version: 0.0.33
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kusk-gateway/crds/gateway.kusk.io_envoyfleet.yaml
+++ b/charts/kusk-gateway/crds/gateway.kusk.io_envoyfleet.yaml
@@ -3,7 +3,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  creationTimestamp: null
   name: envoyfleet.gateway.kusk.io
 spec:
   group: gateway.kusk.io

--- a/charts/kusk-gateway/crds/gateway.kusk.io_envoyfleet.yaml
+++ b/charts/kusk-gateway/crds/gateway.kusk.io_envoyfleet.yaml
@@ -1,7 +1,9 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  creationTimestamp: null
   name: envoyfleet.gateway.kusk.io
 spec:
   group: gateway.kusk.io
@@ -351,9 +353,7 @@ spec:
                                     field and the ones listed in the namespaces field.
                                     null selector and null or empty namespaces list
                                     means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is beta-level
-                                    and is only honored when PodAffinityNamespaceSelector
-                                    feature is enabled.
+                                    ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -408,7 +408,7 @@ spec:
                                     term is applied to the union of the namespaces
                                     listed in this field and the ones selected by
                                     namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace"
+                                    and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
@@ -507,8 +507,6 @@ spec:
                                 the ones listed in the namespaces field. null selector
                                 and null or empty namespaces list means "this pod's
                                 namespace". An empty selector ({}) matches all namespaces.
-                                This field is beta-level and is only honored when
-                                PodAffinityNamespaceSelector feature is enabled.
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label
@@ -559,7 +557,7 @@ spec:
                                 to the union of the namespaces listed in this field
                                 and the ones selected by namespaceSelector. null or
                                 empty namespaces list and null namespaceSelector means
-                                "this pod's namespace"
+                                "this pod's namespace".
                               items:
                                 type: string
                               type: array
@@ -660,9 +658,7 @@ spec:
                                     field and the ones listed in the namespaces field.
                                     null selector and null or empty namespaces list
                                     means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is beta-level
-                                    and is only honored when PodAffinityNamespaceSelector
-                                    feature is enabled.
+                                    ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -717,7 +713,7 @@ spec:
                                     term is applied to the union of the namespaces
                                     listed in this field and the ones selected by
                                     namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace"
+                                    and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
@@ -816,8 +812,6 @@ spec:
                                 the ones listed in the namespaces field. null selector
                                 and null or empty namespaces list means "this pod's
                                 namespace". An empty selector ({}) matches all namespaces.
-                                This field is beta-level and is only honored when
-                                PodAffinityNamespaceSelector feature is enabled.
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label
@@ -868,7 +862,7 @@ spec:
                                 to the union of the namespaces listed in this field
                                 and the ones selected by namespaceSelector. null or
                                 empty namespaces list and null namespaceSelector means
-                                "this pod's namespace"
+                                "this pod's namespace".
                               items:
                                 type: string
                               type: array
@@ -887,47 +881,14 @@ spec:
                         type: array
                     type: object
                 type: object
-              agent:
-                description: Agent sidecar configuration
-                properties:
-                  image:
-                    description: Agent sidecar image tag. If empty (most of the cases)
-                      - will be detected from the Kusk Gateway Manager version and
-                      default Kubeshop container repository
-                    type: string
-                  resources:
-                    description: Agent sidecar CPU and Memory resources requests and
-                      limits
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                    type: object
-                type: object
               annotations:
                 additionalProperties:
                   type: string
                 description: Additional Envoy Deployment annotations, optional
                 type: object
+              default:
+                description: Default marks fleet as the default one in the cluster
+                type: boolean
               image:
                 description: Envoy image tag
                 type: string
@@ -998,7 +959,7 @@ spec:
                           description: The application protocol for this port. This
                             field follows standard Kubernetes label syntax. Un-prefixed
                             names are reserved for IANA standard service names (as
-                            per RFC-6335 and http://www.iana.org/assignments/service-names).
+                            per RFC-6335 and https://www.iana.org/assignments/service-names).
                             Non-standard protocols should use prefixed names such
                             as mycompany.com/my-custom-protocol.
                           type: string
@@ -1173,7 +1134,6 @@ spec:
                   type: object
                 type: array
             required:
-            - image
             - service
             type: object
           status:


### PR DESCRIPTION
## Pull request description 
This PR updates the EnvoyFleet CRD with a new field "default" which denotes whether or not an instance of an EnvoyFleet is the default i.e. if the EnvoyFleet is not specified in an API or Static Route resource, it should be exposed by the default envoy fleet.

Bumped the Kusk Gateway chart version to reflect the changes above.
Bumped the Kusk Gateway API chart version to reflect the changes made in #223 and allowing user to specify whether or not to disable analytics


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
