### PR TITLE
make minio and operator image customizable

### DIFF
--- a/charts/testkube-api/templates/minio.yaml
+++ b/charts/testkube-api/templates/minio.yaml
@@ -48,7 +48,7 @@ spec:
         - name: data
           mountPath: "/data"
         # Pulls the lastest Minio image from Docker Hub
-        image: minio/minio:latest
+        image: {{ .Values.minio.image }}
         args:
         - server
         - /data

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -57,6 +57,7 @@ minio:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  image: minio/minio:latest
   serviceAccountName: ""
 
 uiIngress:

--- a/charts/testkube-operator/templates/deployment.yaml
+++ b/charts/testkube-operator/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: {{ .Values.imageProxy }}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/charts/testkube-operator/values.yaml
+++ b/charts/testkube-operator/values.yaml
@@ -10,6 +10,7 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "1.4.5"
 
+imageProxy: "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"
 imagePullSecrets: []
 nameOverride: "testkube-operator"
 fullnameOverride: "testkube-operator"

--- a/charts/testkube/values-demo.yaml
+++ b/charts/testkube/values-demo.yaml
@@ -120,6 +120,7 @@ testkube-api:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    image: minio/minio:latest
   uiIngress:
     enabled: true
     annotations:
@@ -271,3 +272,6 @@ testkube-dashboard:
       cookieSecret: ""
       cookieSecure: "false"
       redirectUrl: "http://demo.testkube.io/oauth2/callback"
+
+testkube-operator:
+  imageProxy: "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"

--- a/charts/testkube/values-stage.yaml
+++ b/charts/testkube/values-stage.yaml
@@ -120,6 +120,7 @@ testkube-api:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    image: minio/minio:latest
   uiIngress:
     enabled: true
     annotations:
@@ -269,3 +270,6 @@ testkube-dashboard:
       cookieSecret: ""
       cookieSecure: "false"
       redirectUrl: "http://integration.testkube.io/oauth2/callback"
+
+testkube-operator:
+  imageProxy: "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -119,6 +119,7 @@ testkube-api:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    image: minio/minio:latest
   uiIngress:
     enabled: false
     annotations:
@@ -236,3 +237,6 @@ testkube-dashboard:
       cookieSecret: ""
       cookieSecure: "false"
       redirectUrl: "http://demo.testkube.io/oauth2/callback"
+
+testkube-operator:
+  imageProxy: "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"


### PR DESCRIPTION
## Pull request description 
Made `minio` and `operator` images customizable. Now they can be overwritten with: `--set` option


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-