### PR TITLE
Add label kusk-managed: true to managed api and static resource

### DIFF
--- a/charts/kusk-gateway-api/Chart.yaml
+++ b/charts/kusk-gateway-api/Chart.yaml
@@ -17,6 +17,6 @@ keywords:
 
 type: application
 
-version: 0.1.9
+version: 0.1.10
 
 appVersion: "v1.1.2"

--- a/charts/kusk-gateway-api/templates/api.yaml
+++ b/charts/kusk-gateway-api/templates/api.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "kusk-gateway-api.labels" . | nindent 4 }} 
   labels:
     {{- include "kusk-gateway-api.labels" . | nindent 4 }}
+    kusk-managed: "true"
 spec:
   fleet:
     name: {{ .Values.envoyfleet.name }}

--- a/charts/kusk-gateway-dashboard/Chart.yaml
+++ b/charts/kusk-gateway-dashboard/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kusk-gateway-dashboard/templates/staticroute.yaml
+++ b/charts/kusk-gateway-dashboard/templates/staticroute.yaml
@@ -1,7 +1,12 @@
 apiVersion: gateway.kusk.io/v1alpha1
 kind: StaticRoute
 metadata:
-  name: dashboard
+  name: {{ include "dashboard.fullname" . }}
+  annotations:
+    {{- include "dashboard.labels" . | nindent 4 }}
+  labels:
+    {{- include "dashboard.labels" . | nindent 4 }}
+    kusk-managed: "true"
 spec:
   fleet:
     name: {{ .Values.envoyfleet.name }}


### PR DESCRIPTION
## Pull request description 
Add label kusk-managed: true to managed api and static resource so they are filtered out of api calls.

closes https://github.com/kubeshop/kusk-gateway/issues/581

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
