### PR TITLE
Add checksum annotation for configmap contents to kusk gateway deployment

### DIFF
--- a/charts/kusk-gateway/templates/deployment.yaml
+++ b/charts/kusk-gateway/templates/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: kusk-gateway-manager
   namespace: {{ .Release.Namespace }}
+  annotations:
+    checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
   labels:
     {{- include "kusk-gateway.labels" . | nindent 4 }}
     app.kubernetes.io/component: kusk-gateway-manager


### PR DESCRIPTION
This allows us to easily restart the kusk gateway deployment when the contents of the config map change, e.g. the user disables analytics

relates to https://github.com/kubeshop/kusk-gateway/issues/449