### PR TITLE
Upgrade Envoy to `v1.23.1`: Fixes issue with arm64 image

### DIFF
--- a/charts/kusk-gateway-envoyfleet/Chart.yaml
+++ b/charts/kusk-gateway-envoyfleet/Chart.yaml
@@ -26,7 +26,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: 0.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kusk-gateway-envoyfleet/values.yaml
+++ b/charts/kusk-gateway-envoyfleet/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 
 size: 1
 
-image: "envoyproxy/envoy:v1.23.0"
+image: "envoyproxy/envoy:v1.23.1"
 service:
   # NodePort, ClusterIP, LoadBalancer
   type: LoadBalancer


### PR DESCRIPTION
See:

* [`docker.io/envoyproxy/envoy:v1.23.0` `arm64` image fails with `./docker-entrypoint.sh: 29: exec: su-exec: Exec format error`](https://github.com/envoyproxy/envoy/issues/22384).
* [repo: Release 1.23.1](https://github.com/envoyproxy/envoy/pull/22813).

Signed-off-by: Mohamed Bana <mohamed@bana.io>

---

Test:

```sh
$ uname -a
Linux arm64-oracle 5.15.0-1016-oracle #20-Ubuntu SMP Mon Aug 8 07:08:08 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux
$ docker run --rm -it --entrypoint=envoy docker.io/envoyproxy/envoy:v1.23.1 --version

envoy  version: edd69583372955fdfa0b8ca3820dd7312c094e46/1.23.1/Clean/RELEASE/BoringSSL
```

---

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-