### PR TITLE
testkube-api memory request increased to prevent pod OOMKilled

### DIFF
--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -182,7 +182,7 @@ testkube-api:
   resources:
     requests:
       cpu: 200m
-      memory: 50Mi
+      memory: 100Mi
 
   mongodb:
     dsn: "mongodb://testkube-mongodb:27017"


### PR DESCRIPTION
testkube-api memory request increased to prevent pod OOMKilled under high load