### PR TITLE
Update EnvoyFleet CRD with make manifests in kgw

### DIFF
--- a/charts/kusk-gateway-envoyfleet/Chart.yaml
+++ b/charts/kusk-gateway-envoyfleet/Chart.yaml
@@ -26,7 +26,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.5
+version: 0.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kusk-gateway-envoyfleet/Chart.yaml
+++ b/charts/kusk-gateway-envoyfleet/Chart.yaml
@@ -26,7 +26,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.6
+version: 0.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kusk-gateway-envoyfleet/templates/envoyFleet.yaml
+++ b/charts/kusk-gateway-envoyfleet/templates/envoyFleet.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "kusk-gateway-envoyfleet.labels" . | nindent 4 }}
 spec:
-  default: "{{ .Values.default }}"
+  default: {{ .Values.default }}
   size: {{ .Values.size }}
   image: {{ .Values.image }}
   service:

--- a/charts/kusk-gateway-envoyfleet/templates/envoyFleet.yaml
+++ b/charts/kusk-gateway-envoyfleet/templates/envoyFleet.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "kusk-gateway-envoyfleet.labels" . | nindent 4 }}
 spec:
+  default: "{{ .Values.default }}"
   size: {{ .Values.size }}
   image: {{ .Values.image }}
   service:

--- a/charts/kusk-gateway-envoyfleet/values.yaml
+++ b/charts/kusk-gateway-envoyfleet/values.yaml
@@ -7,6 +7,10 @@ fullnameOverride: ""
 
 size: 1
 
+# Specify whether this fleet is the default fleet.
+# APIs and StaticRoutes that do not specify an EnvoyFleet will use the default fleet.
+default: false
+
 image: "envoyproxy/envoy:v1.23.1"
 service:
   # NodePort, ClusterIP, LoadBalancer

--- a/charts/kusk-gateway-envoyfleet/values.yaml
+++ b/charts/kusk-gateway-envoyfleet/values.yaml
@@ -9,7 +9,7 @@ size: 1
 
 # Specify whether this fleet is the default fleet.
 # APIs and StaticRoutes that do not specify an EnvoyFleet will use the default fleet.
-default: false
+default: "false"
 
 image: "envoyproxy/envoy:v1.23.1"
 service:

--- a/charts/kusk-gateway/Chart.yaml
+++ b/charts/kusk-gateway/Chart.yaml
@@ -26,7 +26,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.36
+version: 0.0.37
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kusk-gateway/crds/gateway.kusk.io_envoyfleet.yaml
+++ b/charts/kusk-gateway/crds/gateway.kusk.io_envoyfleet.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -13,964 +12,964 @@ spec:
     singular: envoyfleet
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.size
-      name: size
-      type: integer
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: EnvoyFleet is the Schema for the envoyfleet API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+    - additionalPrinterColumns:
+        - jsonPath: .spec.size
+          name: size
+          type: integer
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: EnvoyFleet is the Schema for the envoyfleet API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: EnvoyFleetSpec defines the desired state of EnvoyFleet
-            properties:
-              accesslog:
-                description: Access logging settings for the Envoy
-                properties:
-                  format:
-                    description: Stdout logging format - text for unstructured and
-                      json for the structured type of logging
-                    enum:
-                    - json
-                    - text
-                    type: string
-                  json_template:
-                    additionalProperties:
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: EnvoyFleetSpec defines the desired state of EnvoyFleet
+              properties:
+                accesslog:
+                  description: Access logging settings for the Envoy
+                  properties:
+                    format:
+                      description: Stdout logging format - text for unstructured and
+                        json for the structured type of logging
+                      enum:
+                        - json
+                        - text
                       type: string
-                    description: Logging format template for the structured json type.
-                      See https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage
-                      for the usage. Uses Kusk Gateway defaults if not specified.
-                    type: object
-                  text_template:
-                    description: Logging format template for the unstructured text
-                      type. See https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage
-                      for the usage. Uses Kusk Gateway defaults if not specified.
+                    json_template:
+                      additionalProperties:
+                        type: string
+                      description: Logging format template for the structured json type.
+                        See https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage
+                        for the usage. Uses Kusk Gateway defaults if not specified.
+                      type: object
+                    text_template:
+                      description: Logging format template for the unstructured text
+                        type. See https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage
+                        for the usage. Uses Kusk Gateway defaults if not specified.
+                      type: string
+                  required:
+                    - format
+                  type: object
+                affinity:
+                  description: Affinity is used to schedule Envoy pod(s) to specific
+                    nodes, optional
+                  properties:
+                    nodeAffinity:
+                      description: Describes node affinity scheduling rules for the
+                        pod.
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods to
+                            nodes that satisfy the affinity expressions specified by
+                            this field, but it may choose a node that violates one or
+                            more of the expressions. The node that is most preferred
+                            is the one with the greatest sum of weights, i.e. for each
+                            node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling affinity expressions,
+                            etc.), compute a sum by iterating through the elements of
+                            this field and adding "weight" to the sum if the node matches
+                            the corresponding matchExpressions; the node(s) with the
+                            highest sum are the most preferred.
+                          items:
+                            description: An empty preferred scheduling term matches
+                              all objects with implicit weight 0 (i.e. it's a no-op).
+                              A null preferred scheduling term matches no objects (i.e.
+                              is also a no-op).
+                            properties:
+                              preference:
+                                description: A node selector term, associated with the
+                                  corresponding weight.
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements
+                                      by node's labels.
+                                    items:
+                                      description: A node selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values. If
+                                            the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values array
+                                            must be empty. If the operator is Gt or
+                                            Lt, the values array must have a single
+                                            element, which will be interpreted as an
+                                            integer. This array is replaced during a
+                                            strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    description: A list of node selector requirements
+                                      by node's fields.
+                                    items:
+                                      description: A node selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values. If
+                                            the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values array
+                                            must be empty. If the operator is Gt or
+                                            Lt, the values array must have a single
+                                            element, which will be interpreted as an
+                                            integer. This array is replaced during a
+                                            strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              weight:
+                                description: Weight associated with matching the corresponding
+                                  nodeSelectorTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - preference
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this
+                            field are not met at scheduling time, the pod will not be
+                            scheduled onto the node. If the affinity requirements specified
+                            by this field cease to be met at some point during pod execution
+                            (e.g. due to an update), the system may or may not try to
+                            eventually evict the pod from its node.
+                          properties:
+                            nodeSelectorTerms:
+                              description: Required. A list of node selector terms.
+                                The terms are ORed.
+                              items:
+                                description: A null or empty node selector term matches
+                                  no objects. The requirements of them are ANDed. The
+                                  TopologySelectorTerm type implements a subset of the
+                                  NodeSelectorTerm.
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements
+                                      by node's labels.
+                                    items:
+                                      description: A node selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values. If
+                                            the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values array
+                                            must be empty. If the operator is Gt or
+                                            Lt, the values array must have a single
+                                            element, which will be interpreted as an
+                                            integer. This array is replaced during a
+                                            strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    description: A list of node selector requirements
+                                      by node's fields.
+                                    items:
+                                      description: A node selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values. If
+                                            the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values array
+                                            must be empty. If the operator is Gt or
+                                            Lt, the values array must have a single
+                                            element, which will be interpreted as an
+                                            integer. This array is replaced during a
+                                            strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          required:
+                            - nodeSelectorTerms
+                          type: object
+                      type: object
+                    podAffinity:
+                      description: Describes pod affinity scheduling rules (e.g. co-locate
+                        this pod in the same node, zone, etc. as some other pod(s)).
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods to
+                            nodes that satisfy the affinity expressions specified by
+                            this field, but it may choose a node that violates one or
+                            more of the expressions. The node that is most preferred
+                            is the one with the greatest sum of weights, i.e. for each
+                            node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling affinity expressions,
+                            etc.), compute a sum by iterating through the elements of
+                            this field and adding "weight" to the sum if the node has
+                            pods which matches the corresponding podAffinityTerm; the
+                            node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm
+                              fields are added per-node to find the most preferred node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated
+                                  with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list
+                                      means "this pod's namespace". An empty selector
+                                      ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to. The
+                                      term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces list
+                                      and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                description: weight associated with matching the corresponding
+                                  podAffinityTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this
+                            field are not met at scheduling time, the pod will not be
+                            scheduled onto the node. If the affinity requirements specified
+                            by this field cease to be met at some point during pod execution
+                            (e.g. due to a pod label update), the system may or may
+                            not try to eventually evict the pod from its node. When
+                            there are multiple elements, the lists of nodes corresponding
+                            to each podAffinityTerm are intersected, i.e. all terms
+                            must be satisfied.
+                          items:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not co-located
+                              (anti-affinity) with, where co-located is defined as running
+                              on a node whose value of the label with key <topologyKey>
+                              matches that of any node on which a pod of the set of
+                              pods is running
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the
+                                            operator is Exists or DoesNotExist, the
+                                            values array must be empty. This array is
+                                            replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value". The
+                                      requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaceSelector:
+                                description: A label query over the set of namespaces
+                                  that the term applies to. The term is applied to the
+                                  union of the namespaces selected by this field and
+                                  the ones listed in the namespaces field. null selector
+                                  and null or empty namespaces list means "this pod's
+                                  namespace". An empty selector ({}) matches all namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the
+                                            operator is Exists or DoesNotExist, the
+                                            values array must be empty. This array is
+                                            replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value". The
+                                      requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies a static list of namespace
+                                  names that the term applies to. The term is applied
+                                  to the union of the namespaces listed in this field
+                                  and the ones selected by namespaceSelector. null or
+                                  empty namespaces list and null namespaceSelector means
+                                  "this pod's namespace".
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods matching
+                                  the labelSelector in the specified namespaces, where
+                                  co-located is defined as running on a node whose value
+                                  of the label with key topologyKey matches that of
+                                  any node on which any of the selected pods is running.
+                                  Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    podAntiAffinity:
+                      description: Describes pod anti-affinity scheduling rules (e.g.
+                        avoid putting this pod in the same node, zone, etc. as some
+                        other pod(s)).
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods to
+                            nodes that satisfy the anti-affinity expressions specified
+                            by this field, but it may choose a node that violates one
+                            or more of the expressions. The node that is most preferred
+                            is the one with the greatest sum of weights, i.e. for each
+                            node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling anti-affinity expressions,
+                            etc.), compute a sum by iterating through the elements of
+                            this field and adding "weight" to the sum if the node has
+                            pods which matches the corresponding podAffinityTerm; the
+                            node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm
+                              fields are added per-node to find the most preferred node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated
+                                  with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list
+                                      means "this pod's namespace". An empty selector
+                                      ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to. The
+                                      term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces list
+                                      and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                description: weight associated with matching the corresponding
+                                  podAffinityTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the anti-affinity requirements specified by
+                            this field are not met at scheduling time, the pod will
+                            not be scheduled onto the node. If the anti-affinity requirements
+                            specified by this field cease to be met at some point during
+                            pod execution (e.g. due to a pod label update), the system
+                            may or may not try to eventually evict the pod from its
+                            node. When there are multiple elements, the lists of nodes
+                            corresponding to each podAffinityTerm are intersected, i.e.
+                            all terms must be satisfied.
+                          items:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not co-located
+                              (anti-affinity) with, where co-located is defined as running
+                              on a node whose value of the label with key <topologyKey>
+                              matches that of any node on which a pod of the set of
+                              pods is running
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the
+                                            operator is Exists or DoesNotExist, the
+                                            values array must be empty. This array is
+                                            replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value". The
+                                      requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaceSelector:
+                                description: A label query over the set of namespaces
+                                  that the term applies to. The term is applied to the
+                                  union of the namespaces selected by this field and
+                                  the ones listed in the namespaces field. null selector
+                                  and null or empty namespaces list means "this pod's
+                                  namespace". An empty selector ({}) matches all namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the
+                                            operator is Exists or DoesNotExist, the
+                                            values array must be empty. This array is
+                                            replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value". The
+                                      requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies a static list of namespace
+                                  names that the term applies to. The term is applied
+                                  to the union of the namespaces listed in this field
+                                  and the ones selected by namespaceSelector. null or
+                                  empty namespaces list and null namespaceSelector means
+                                  "this pod's namespace".
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods matching
+                                  the labelSelector in the specified namespaces, where
+                                  co-located is defined as running on a node whose value
+                                  of the label with key topologyKey matches that of
+                                  any node on which any of the selected pods is running.
+                                  Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                annotations:
+                  additionalProperties:
                     type: string
-                required:
-                - format
-                type: object
-              affinity:
-                description: Affinity is used to schedule Envoy pod(s) to specific
-                  nodes, optional
-                properties:
-                  nodeAffinity:
-                    description: Describes node affinity scheduling rules for the
-                      pod.
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node matches
-                          the corresponding matchExpressions; the node(s) with the
-                          highest sum are the most preferred.
-                        items:
-                          description: An empty preferred scheduling term matches
-                            all objects with implicit weight 0 (i.e. it's a no-op).
-                            A null preferred scheduling term matches no objects (i.e.
-                            is also a no-op).
-                          properties:
-                            preference:
-                              description: A node selector term, associated with the
-                                corresponding weight.
-                              properties:
-                                matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            weight:
-                              description: Weight associated with matching the corresponding
-                                nodeSelectorTerm, in the range 1-100.
-                              format: int32
-                              type: integer
-                          required:
-                          - preference
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to an update), the system may or may not try to
-                          eventually evict the pod from its node.
-                        properties:
-                          nodeSelectorTerms:
-                            description: Required. A list of node selector terms.
-                              The terms are ORed.
-                            items:
-                              description: A null or empty node selector term matches
-                                no objects. The requirements of them are ANDed. The
-                                TopologySelectorTerm type implements a subset of the
-                                NodeSelectorTerm.
-                              properties:
-                                matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
-                                  items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: The label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
-                                        type: string
-                                      values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            type: array
-                        required:
-                        - nodeSelectorTerms
-                        type: object
-                    type: object
-                  podAffinity:
-                    description: Describes pod affinity scheduling rules (e.g. co-locate
-                      this pod in the same node, zone, etc. as some other pod(s)).
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
-                        items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
-                          properties:
-                            podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                namespaceSelector:
-                                  description: A label query over the set of namespaces
-                                    that the term applies to. The term is applied
-                                    to the union of the namespaces selected by this
-                                    field and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list
-                                    means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  description: namespaces specifies a static list
-                                    of namespace names that the term applies to. The
-                                    term is applied to the union of the namespaces
-                                    listed in this field and the ones selected by
-                                    namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace".
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
-                              format: int32
-                              type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to a pod label update), the system may or may
-                          not try to eventually evict the pod from its node. When
-                          there are multiple elements, the lists of nodes corresponding
-                          to each podAffinityTerm are intersected, i.e. all terms
-                          must be satisfied.
-                        items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
-                          properties:
-                            labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
-                                  type: object
-                              type: object
-                            namespaceSelector:
-                              description: A label query over the set of namespaces
-                                that the term applies to. The term is applied to the
-                                union of the namespaces selected by this field and
-                                the ones listed in the namespaces field. null selector
-                                and null or empty namespaces list means "this pod's
-                                namespace". An empty selector ({}) matches all namespaces.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
-                                  type: object
-                              type: object
-                            namespaces:
-                              description: namespaces specifies a static list of namespace
-                                names that the term applies to. The term is applied
-                                to the union of the namespaces listed in this field
-                                and the ones selected by namespaceSelector. null or
-                                empty namespaces list and null namespaceSelector means
-                                "this pod's namespace".
-                              items:
-                                type: string
-                              type: array
-                            topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                  podAntiAffinity:
-                    description: Describes pod anti-affinity scheduling rules (e.g.
-                      avoid putting this pod in the same node, zone, etc. as some
-                      other pod(s)).
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the anti-affinity expressions specified
-                          by this field, but it may choose a node that violates one
-                          or more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling anti-affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
-                        items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
-                          properties:
-                            podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                namespaceSelector:
-                                  description: A label query over the set of namespaces
-                                    that the term applies to. The term is applied
-                                    to the union of the namespaces selected by this
-                                    field and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list
-                                    means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  description: namespaces specifies a static list
-                                    of namespace names that the term applies to. The
-                                    term is applied to the union of the namespaces
-                                    listed in this field and the ones selected by
-                                    namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace".
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
-                              format: int32
-                              type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the anti-affinity requirements specified by
-                          this field are not met at scheduling time, the pod will
-                          not be scheduled onto the node. If the anti-affinity requirements
-                          specified by this field cease to be met at some point during
-                          pod execution (e.g. due to a pod label update), the system
-                          may or may not try to eventually evict the pod from its
-                          node. When there are multiple elements, the lists of nodes
-                          corresponding to each podAffinityTerm are intersected, i.e.
-                          all terms must be satisfied.
-                        items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
-                          properties:
-                            labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
-                                  type: object
-                              type: object
-                            namespaceSelector:
-                              description: A label query over the set of namespaces
-                                that the term applies to. The term is applied to the
-                                union of the namespaces selected by this field and
-                                the ones listed in the namespaces field. null selector
-                                and null or empty namespaces list means "this pod's
-                                namespace". An empty selector ({}) matches all namespaces.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
-                                  type: object
-                              type: object
-                            namespaces:
-                              description: namespaces specifies a static list of namespace
-                                names that the term applies to. The term is applied
-                                to the union of the namespaces listed in this field
-                                and the ones selected by namespaceSelector. null or
-                                empty namespaces list and null namespaceSelector means
-                                "this pod's namespace".
-                              items:
-                                type: string
-                              type: array
-                            topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                type: object
-              annotations:
-                additionalProperties:
+                  description: Additional Envoy Deployment annotations, optional
+                  type: object
+                default:
+                  description: Default marks fleet as the default one in the cluster
+                  type: boolean
+                image:
+                  description: Envoy image tag
                   type: string
-                description: Additional Envoy Deployment annotations, optional
-                type: object
-              default:
-                description: Default marks fleet as the default one in the cluster
-                type: boolean
-              image:
-                description: Envoy image tag
-                type: string
-              nodeSelector:
-                additionalProperties:
-                  type: string
-                description: 'Node Selector is used to schedule the Envoy pod(s) to
+                nodeSelector:
+                  additionalProperties:
+                    type: string
+                  description: 'Node Selector is used to schedule the Envoy pod(s) to
                   the specificly labeled nodes, optional This is the map of "key:
                   value" labels (e.g. "disktype": "ssd")'
-                type: object
-              resources:
-                description: Resources allow to set CPU and Memory resource requests
-                  and limits, optional
-                properties:
-                  limits:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
+                  type: object
+                resources:
+                  description: Resources allow to set CPU and Memory resource requests
+                    and limits, optional
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute resources
                       allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                    type: object
-                  requests:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
                       resources required. If Requests is omitted for a container,
                       it defaults to Limits if that is explicitly specified, otherwise
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                    type: object
-                type: object
-              service:
-                description: Service describes Envoy K8s service settings
-                properties:
-                  annotations:
-                    additionalProperties:
+                      type: object
+                  type: object
+                service:
+                  description: Service describes Envoy K8s service settings
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Service's annotations
+                      type: object
+                    externalTrafficPolicy:
+                      description: externalTrafficPolicy denotes if this Service desires
+                        to route external traffic to node-local or cluster-wide endpoints.
+                        "Local" preserves the client source IP and avoids a second hop
+                        for LoadBalancer and Nodeport type services, but risks potentially
+                        imbalanced traffic spreading. "Cluster" obscures the client
+                        source IP and may cause a second hop to another node, but should
+                        have good overall load-spreading. For the preservation of the
+                        real client ip in access logs chose "Local"
+                      enum:
+                        - Cluster
+                        - Local
                       type: string
-                    description: Service's annotations
-                    type: object
-                  externalTrafficPolicy:
-                    description: externalTrafficPolicy denotes if this Service desires
-                      to route external traffic to node-local or cluster-wide endpoints.
-                      "Local" preserves the client source IP and avoids a second hop
-                      for LoadBalancer and Nodeport type services, but risks potentially
-                      imbalanced traffic spreading. "Cluster" obscures the client
-                      source IP and may cause a second hop to another node, but should
-                      have good overall load-spreading. For the preservation of the
-                      real client ip in access logs chose "Local"
-                    enum:
-                    - Cluster
-                    - Local
-                    type: string
-                  loadBalancerIP:
-                    description: Static ip address for the LoadBalancer type if available
-                    type: string
-                  ports:
-                    description: Kubernetes Service ports
-                    items:
-                      description: ServicePort contains information on service's port.
-                      properties:
-                        appProtocol:
-                          description: The application protocol for this port. This
-                            field follows standard Kubernetes label syntax. Un-prefixed
-                            names are reserved for IANA standard service names (as
-                            per RFC-6335 and https://www.iana.org/assignments/service-names).
-                            Non-standard protocols should use prefixed names such
-                            as mycompany.com/my-custom-protocol.
-                          type: string
-                        name:
-                          description: The name of this port within the service. This
-                            must be a DNS_LABEL. All ports within a ServiceSpec must
-                            have unique names. When considering the endpoints for
-                            a Service, this must match the 'name' field in the EndpointPort.
-                            Optional if only one ServicePort is defined on this service.
-                          type: string
-                        nodePort:
-                          description: 'The port on each node on which this service
+                    loadBalancerIP:
+                      description: Static ip address for the LoadBalancer type if available
+                      type: string
+                    ports:
+                      description: Kubernetes Service ports
+                      items:
+                        description: ServicePort contains information on service's port.
+                        properties:
+                          appProtocol:
+                            description: The application protocol for this port. This
+                              field follows standard Kubernetes label syntax. Un-prefixed
+                              names are reserved for IANA standard service names (as
+                              per RFC-6335 and https://www.iana.org/assignments/service-names).
+                              Non-standard protocols should use prefixed names such
+                              as mycompany.com/my-custom-protocol.
+                            type: string
+                          name:
+                            description: The name of this port within the service. This
+                              must be a DNS_LABEL. All ports within a ServiceSpec must
+                              have unique names. When considering the endpoints for
+                              a Service, this must match the 'name' field in the EndpointPort.
+                              Optional if only one ServicePort is defined on this service.
+                            type: string
+                          nodePort:
+                            description: 'The port on each node on which this service
                             is exposed when type is NodePort or LoadBalancer.  Usually
                             assigned by the system. If a value is specified, in-range,
                             and not in use it will be used, otherwise the operation
@@ -980,22 +979,22 @@ spec:
                             will fail. This field will be wiped when updating a Service
                             to no longer need it (e.g. changing type from NodePort
                             to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
-                          format: int32
-                          type: integer
-                        port:
-                          description: The port that will be exposed by this service.
-                          format: int32
-                          type: integer
-                        protocol:
-                          default: TCP
-                          description: The IP protocol for this port. Supports "TCP",
-                            "UDP", and "SCTP". Default is TCP.
-                          type: string
-                        targetPort:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          description: 'Number or name of the port to access on the
+                            format: int32
+                            type: integer
+                          port:
+                            description: The port that will be exposed by this service.
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: The IP protocol for this port. Supports "TCP",
+                              "UDP", and "SCTP". Default is TCP.
+                            type: string
+                          targetPort:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            description: 'Number or name of the port to access on the
                             pods targeted by the service. Number must be in the range
                             1 to 65535. Name must be an IANA_SVC_NAME. If this is
                             a string, it will be looked up as a named port in the
@@ -1004,151 +1003,151 @@ spec:
                             This field is ignored for services with clusterIP=None,
                             and should be omitted or set equal to the ''port'' field.
                             More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
-                          x-kubernetes-int-or-string: true
-                      required:
-                      - port
-                      type: object
-                    type: array
-                  type:
-                    description: 'Kubernetes service type: NodePort, ClusterIP or
+                            x-kubernetes-int-or-string: true
+                        required:
+                          - port
+                        type: object
+                      type: array
+                    type:
+                      description: 'Kubernetes service type: NodePort, ClusterIP or
                       LoadBalancer'
-                    enum:
-                    - NodePort
-                    - ClusterIP
-                    - LoadBalancer
-                    type: string
-                required:
-                - ports
-                - type
-                type: object
-              size:
-                default: 1
-                description: Size field specifies the number of Envoy Pods being deployed.
-                  Optional, default value is 1.
-                format: int32
-                minimum: 1
-                type: integer
-              terminationGracePeriodSeconds:
-                description: Optional duration in seconds the pod needs to terminate
-                  gracefully. May be decreased in delete request. Value must be non-negative
-                  integer. The value zero indicates stop immediately via the kill
-                  signal (no opportunity to shut down). If this value is nil, the
-                  default grace period will be used instead. The grace period is the
-                  duration in seconds after the processes running in the pod are sent
-                  a termination signal and the time when the processes are forcibly
-                  halted with a kill signal. Set this value longer than the expected
-                  cleanup time for your process. Defaults to 30 seconds.
-                format: int64
-                type: integer
-              tls:
-                description: TLS configuration
-                properties:
-                  cipherSuites:
-                    description: 'If specified, the TLS listener will only support
+                      enum:
+                        - NodePort
+                        - ClusterIP
+                        - LoadBalancer
+                      type: string
+                  required:
+                    - ports
+                    - type
+                  type: object
+                size:
+                  default: 1
+                  description: Size field specifies the number of Envoy Pods being deployed.
+                    Optional, default value is 1.
+                  format: int32
+                  minimum: 1
+                  type: integer
+                terminationGracePeriodSeconds:
+                  description: Optional duration in seconds the pod needs to terminate
+                    gracefully. May be decreased in delete request. Value must be non-negative
+                    integer. The value zero indicates stop immediately via the kill
+                    signal (no opportunity to shut down). If this value is nil, the
+                    default grace period will be used instead. The grace period is the
+                    duration in seconds after the processes running in the pod are sent
+                    a termination signal and the time when the processes are forcibly
+                    halted with a kill signal. Set this value longer than the expected
+                    cleanup time for your process. Defaults to 30 seconds.
+                  format: int64
+                  type: integer
+                tls:
+                  description: TLS configuration
+                  properties:
+                    cipherSuites:
+                      description: 'If specified, the TLS listener will only support
                       the specified cipher list when negotiating TLS 1.0-1.2 (this
                       setting has no effect when negotiating TLS 1.3). If not specified,
                       a default list will be used. Defaults are different for server
                       (downstream) and client (upstream) TLS configurations. For more
                       information see: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto'
-                    items:
+                      items:
+                        type: string
+                      type: array
+                    https_redirect_hosts:
+                      description: List of host names to enforce HTTPS redirect for.
+                        That is if a HTTP request is received on a host in this list
+                        a 301 redirect will be sent telling the client to use HTTPS
+                      items:
+                        type: string
+                      type: array
+                    tlsMaximumProtocolVersion:
+                      description: Maximum TLS protocol version. By default, it’s TLSv1_2
+                        for clients and TLSv1_3 for servers.
                       type: string
-                    type: array
-                  https_redirect_hosts:
-                    description: List of host names to enforce HTTPS redirect for.
-                      That is if a HTTP request is received on a host in this list
-                      a 301 redirect will be sent telling the client to use HTTPS
-                    items:
+                    tlsMinimumProtocolVersion:
+                      description: Minimum TLS protocol version. By default, it’s TLSv1_2
+                        for clients and TLSv1_0 for servers.
                       type: string
-                    type: array
-                  tlsMaximumProtocolVersion:
-                    description: Maximum TLS protocol version. By default, it’s TLSv1_2
-                      for clients and TLSv1_3 for servers.
-                    type: string
-                  tlsMinimumProtocolVersion:
-                    description: Minimum TLS protocol version. By default, it’s TLSv1_2
-                      for clients and TLSv1_0 for servers.
-                    type: string
-                  tlsSecrets:
-                    description: 'SecretName and Namespace combinations for locating
+                    tlsSecrets:
+                      description: 'SecretName and Namespace combinations for locating
                       TLS secrets containing TLS certificates You can specify more
                       than one For more information on how certificate selection works
                       see: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/ssl#certificate-selection'
-                    items:
-                      properties:
-                        namespace:
-                          description: Namespace where the Kubernetes certificate
-                            resides
-                          type: string
-                        secretRef:
-                          description: Name of the Kubernetes secret containing the
-                            TLS certificate
-                          type: string
-                      required:
-                      - namespace
-                      - secretRef
-                      type: object
-                    type: array
-                required:
-                - tlsSecrets
-                type: object
-              tolerations:
-                description: Tolerations allow pod to be scheduled to the nodes that
-                  has specific toleration labels, optional
-                items:
-                  description: The pod this Toleration is attached to tolerates any
-                    taint that matches the triple <key,value,effect> using the matching
-                    operator <operator>.
-                  properties:
-                    effect:
-                      description: Effect indicates the taint effect to match. Empty
-                        means match all taint effects. When specified, allowed values
-                        are NoSchedule, PreferNoSchedule and NoExecute.
-                      type: string
-                    key:
-                      description: Key is the taint key that the toleration applies
-                        to. Empty means match all taint keys. If the key is empty,
-                        operator must be Exists; this combination means to match all
-                        values and all keys.
-                      type: string
-                    operator:
-                      description: Operator represents a key's relationship to the
-                        value. Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod
-                        can tolerate all taints of a particular category.
-                      type: string
-                    tolerationSeconds:
-                      description: TolerationSeconds represents the period of time
-                        the toleration (which must be of effect NoExecute, otherwise
-                        this field is ignored) tolerates the taint. By default, it
-                        is not set, which means tolerate the taint forever (do not
-                        evict). Zero and negative values will be treated as 0 (evict
-                        immediately) by the system.
-                      format: int64
-                      type: integer
-                    value:
-                      description: Value is the taint value the toleration matches
-                        to. If the operator is Exists, the value should be empty,
-                        otherwise just a regular string.
-                      type: string
+                      items:
+                        properties:
+                          namespace:
+                            description: Namespace where the Kubernetes certificate
+                              resides
+                            type: string
+                          secretRef:
+                            description: Name of the Kubernetes secret containing the
+                              TLS certificate
+                            type: string
+                        required:
+                          - namespace
+                          - secretRef
+                        type: object
+                      type: array
+                  required:
+                    - tlsSecrets
                   type: object
-                type: array
-            required:
-            - service
-            type: object
-          status:
-            description: EnvoyFleetStatus defines the observed state of EnvoyFleet
-            properties:
-              state:
-                description: State indicates Envoy Fleet state
-                type: string
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                tolerations:
+                  description: Tolerations allow pod to be scheduled to the nodes that
+                    has specific toleration labels, optional
+                  items:
+                    description: The pod this Toleration is attached to tolerates any
+                      taint that matches the triple <key,value,effect> using the matching
+                      operator <operator>.
+                    properties:
+                      effect:
+                        description: Effect indicates the taint effect to match. Empty
+                          means match all taint effects. When specified, allowed values
+                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Key is the taint key that the toleration applies
+                          to. Empty means match all taint keys. If the key is empty,
+                          operator must be Exists; this combination means to match all
+                          values and all keys.
+                        type: string
+                      operator:
+                        description: Operator represents a key's relationship to the
+                          value. Valid operators are Exists and Equal. Defaults to Equal.
+                          Exists is equivalent to wildcard for value, so that a pod
+                          can tolerate all taints of a particular category.
+                        type: string
+                      tolerationSeconds:
+                        description: TolerationSeconds represents the period of time
+                          the toleration (which must be of effect NoExecute, otherwise
+                          this field is ignored) tolerates the taint. By default, it
+                          is not set, which means tolerate the taint forever (do not
+                          evict). Zero and negative values will be treated as 0 (evict
+                          immediately) by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: Value is the taint value the toleration matches
+                          to. If the operator is Exists, the value should be empty,
+                          otherwise just a regular string.
+                        type: string
+                    type: object
+                  type: array
+              required:
+                - service
+              type: object
+            status:
+              description: EnvoyFleetStatus defines the observed state of EnvoyFleet
+              properties:
+                state:
+                  description: State indicates Envoy Fleet state
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
## Pull request description 
This regenerates the EnvoyFleet CRD and includes the recently added Default field which specifies whether or not this is a default envoyfleet


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

