### PR TITLE
Tracetest: add httpPort config

### DIFF
--- a/charts/tracetest/templates/deployment.yaml
+++ b/charts/tracetest/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: {{ .Values.server.httpPort }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/tracetest/values.yaml
+++ b/charts/tracetest/values.yaml
@@ -43,6 +43,7 @@ telemetry:
           endpoint: otel-collector:4317
 
 server:
+  httpPort: 8080
   telemetry:
     exporter: collector
     applicationExporter: collector


### PR DESCRIPTION
## Pull request description 

This pr allows to configure the http port on which tracetest will listen, and set the deployment accordingly

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-