### PR TITLE
feat: fix wrong testkube operator rbac

### DIFF
--- a/charts/testkube-api/templates/role.yaml
+++ b/charts/testkube-api/templates/role.yaml
@@ -263,7 +263,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - "apps/v1"
+      - "apps"
     resources:
       - deployments
       - daemonsets
@@ -273,15 +273,8 @@ rules:
       - list
       - watch
   - apiGroups:
-      - "networking.k8s.io/v1"
-    resources:
-      - ingresses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "extensions/v1"
+      - "networking.k8s.io"
+      - "extensions"
     resources:
       - ingresses
     verbs:


### PR DESCRIPTION
## Pull request description 
Remove version from apiGroup in ClusterRole

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

- Rename api groups

## Fixes

- TestKube API erroring with insufficient permissions to watch resources