### PR TITLE
Update certmanagement.yaml

### DIFF
--- a/charts/testkube-operator/templates/certmanagement.yaml
+++ b/charts/testkube-operator/templates/certmanagement.yaml
@@ -3,6 +3,10 @@ kind: Job
 metadata:
   name: cert-creation-{{ .Release.Revision }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   ttlSecondsAfterFinished: 100
   template:


### PR DESCRIPTION
Adding helm hook annotations (https://helm.sh/docs/topics/charts_hooks/) to cert job, specifying when the job should be executed (pre-install and pre-upgrade).

The lack of annotations causes out-of-sync issues when deploying the helm charts through gitops-type apps, like argocd, as it is shown as missing after being automatically cleaned up after completion.

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-n/a

## Changes

- Specified explicitly when cert creation job should execute.

## Fixes

- Deploying testkube charts through argocd.