### PR TITLE
Update certmanagement.yaml

### DIFF
--- a/charts/testkube-operator/templates/certmanagement.yaml
+++ b/charts/testkube-operator/templates/certmanagement.yaml
@@ -40,7 +40,7 @@ metadata:
   name: cert-creation
   namespace: {{ .Release.Namespace }}
 spec:
-  schedule: "* * * */3 *"
+  schedule: "0 0 1 */3 *"
   jobTemplate:
     spec:
       ttlSecondsAfterFinished: 100


### PR DESCRIPTION
## Pull request description 
I assume the intention is to trigger this cronjob once every 3 months, however as written this cronjob would trigger once every minute of every hour of every day, every three months (leading to a lot of triggers that specific month).

This change will cause the cronjob to trigger at 00:00 on the first of the month, every three months.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

- n/a

## Changes

- n/a

## Fixes
Error in cronjob schedule definiton
-