### PR TITLE
feat: testkube add activeDeadlineSeconds

### DIFF
--- a/charts/testkube-api/job-template.yml
+++ b/charts/testkube-api/job-template.yml
@@ -4,6 +4,9 @@ metadata:
   name: {{ .Name }}
   namespace: {{ .Namespace }}
 spec:
+  {{- if gt .ActiveDeadlineSeconds 0}}
+  activeDeadlineSeconds: {{ .ActiveDeadlineSeconds }}
+  {{- end}}
   template:
     spec:
       initContainers:

--- a/charts/testkube-operator/templates/tests.testkube.io_tests.yaml
+++ b/charts/testkube-operator/templates/tests.testkube.io_tests.yaml
@@ -431,6 +431,13 @@ spec:
                 executionRequest:
                   description: test execution request body
                   properties:
+                    activeDeadlineSeconds:
+                      description: Optional duration in seconds the pod may be active
+                        on the node relative to StartTime before the system will actively
+                        try to mark it failed and kill associated containers. Value
+                        must be a positive integer.
+                      format: int64
+                      type: integer
                     args:
                       description: additional executor binary arguments
                       items:


### PR DESCRIPTION
## Pull request description 

add activeDeadlineSeconds to tests CRD and template 

Related: https://github.com/kubeshop/testkube/issues/2296

related: https://github.com/kubeshop/testkube-operator/pull/88

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-