### PR TITLE
testkube-api: add namespaces to watcher role for API RBAC

### DIFF
--- a/charts/testkube-api/templates/role.yaml
+++ b/charts/testkube-api/templates/role.yaml
@@ -253,32 +253,33 @@ kind: ClusterRole
 metadata:
   name: watchers-cluster-role-{{ .Release.Name }}
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - services
-      - events
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apps"
-    resources:
-      - deployments
-      - daemonsets
-      - statefulsets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "networking.k8s.io"
-      - "extensions"
-    resources:
-      - ingresses
-    verbs:
-      - get
-      - list
-      - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - events
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - daemonsets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "networking.k8s.io"
+  - "extensions"
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
## Pull request description 

Fixes issue with testkube trigger api returning errors due to no permissions to list namespaces

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

- Issue with testkube trigger api returning errors due to no permissions to list namespaces