### PR TITLE
Kusk Gateway API - envoy fleet pod logs streaming over websocket

### DIFF
--- a/charts/kusk-gateway-api/Chart.yaml
+++ b/charts/kusk-gateway-api/Chart.yaml
@@ -17,6 +17,6 @@ keywords:
 
 type: application
 
-version: 0.1.22
+version: 0.1.23
 
 appVersion: "v1.1.10"

--- a/charts/kusk-gateway-api/templates/api.yaml
+++ b/charts/kusk-gateway-api/templates/api.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: gateway.kusk.io/v1alpha1
 kind: API
@@ -703,6 +702,39 @@ spec:
           summary: Get static route CRD
           tags:
           - static routes
+      /logs:
+        x-kusk:
+          upstream:
+            service:
+              name: {{ include "kusk-gateway-api.fullname" . }}-websocket
+              namespace: {{ .Release.Namespace }}
+              port: 8081
+          websocket: true
+        get:
+          tags:
+            - "fleets"
+          summary: "Get envoy fleet logs"
+          operationId: getEnvoyFleetLogs
+          parameters:
+            - name: namespace
+              in: query
+              schema:
+                type: string
+                default: "kusk-system"
+            - name: name
+              in: query
+              schema:
+                type: string
+                default: "kusk-gateway-envoy-fleet"
+          responses:
+            200:
+              description: "Envoy fleet logs"
+              content:
+                application/json:
+                  schema:
+                    type: object
+            404:
+              description: "Envoy fleet logs not found"
     servers:
     - description: My local endpoint mockup
       url: http://localhost:8080

--- a/charts/kusk-gateway-api/templates/clusterrole.yaml
+++ b/charts/kusk-gateway-api/templates/clusterrole.yaml
@@ -70,6 +70,8 @@ rules:
   resources:
     - services
     - namespaces
+    - pods
+    - pods/logs
   verbs:
     - get
     - list

--- a/charts/kusk-gateway-api/templates/deployment.yaml
+++ b/charts/kusk-gateway-api/templates/deployment.yaml
@@ -50,6 +50,23 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        - name: kusk-gateway-api-websocket
+          image: "{{ .Values.image.repository }}-websocket:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: ws
+              containerPort: 8081
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: ws
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: ws
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Pull request description 
- Add websocket container to kusk-gateway-api deployment
- Add rbac permissions allowed the websocket process to poll pod logs
- add log endpoint to kusk gateway api's api spec

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-