### PR TITLE
Testkube - staging tests

### DIFF
--- a/.github/workflows/helm-deploy-testkube-charts-stage.yaml
+++ b/.github/workflows/helm-deploy-testkube-charts-stage.yaml
@@ -22,8 +22,8 @@ env:
   GKE_ZONE_STAGE: ${{ secrets.GKE_ZONE_STAGE }} # Add your cluster zone here.
   DEPLOYMENT_NAME: testkube # Add your deployment name here.
   ENV: stage
-  POSTMAN_TEST_FILE_NANE: TestKube-Sanity.postman_collection.json
-  POSTMAN_TEST_FILE_PATH: test/postman
+  # POSTMAN_TEST_FILE_NANE: TestKube-Sanity.postman_collection.json //TODO: remove - not needed anymore
+  # POSTMAN_TEST_FILE_PATH: test/postman //TODO: remove - not needed anymore
 
 jobs:
   # release_charts_if_image_updated:
@@ -155,13 +155,16 @@ jobs:
           cluster_name: ${{ env.GKE_CLUSTER_NAME_STAGE }}
           location: ${{ env.GKE_ZONE_STAGE }}
           credentials: ${{ secrets.GKE_SA_KEY }}
+      - name: Install testkube kubectl plugin
+        run: bash < <(curl -sSLf https://kubeshop.github.io/testkube/install.sh )
       - name: Checkout tests from main Testkube repo
         uses: actions/checkout@master
         with:
           repository: kubeshop/testkube
           path: testkube-repo
-      - name: ls
-        run: echo "Main dir \n"; ls -lah; cd testkube-repo; echo "testkube-repo dir \n"; ls -lah
+      - name: Testkube smoke tests - run script
+        working-directory: ./testkube-repo
+        run: chmod +x ./test/scripts/executor-tests/run.sh && ./test/scripts/executor-tests/run.sh -d -c -s -e soapui-smoke
 
       # # Runnning test suite
       # - name: Run test suite
@@ -170,10 +173,10 @@ jobs:
       #     set -x
 
       #     # Installing testkube kubectl plugin:
-      #     bash < <(curl -sSLf https://kubeshop.github.io/testkube/install.sh )
+      #     # bash < <(curl -sSLf https://kubeshop.github.io/testkube/install.sh ) //TODO: remove - moved to separate step
 
       #     # Downloading test suite:
-      #     curl -LOs https://raw.githubusercontent.com/kubeshop/testkube/main/${{ env.POSTMAN_TEST_FILE_PATH }}/${{ env.POSTMAN_TEST_FILE_NANE }}
+      #     # curl -LOs https://raw.githubusercontent.com/kubeshop/testkube/main/${{ env.POSTMAN_TEST_FILE_PATH }}/${{ env.POSTMAN_TEST_FILE_NANE }} //TODO: remove - repo checkout instead
 
       #     # Running Test suite:
       #     kubectl testkube disable telemetry

--- a/.github/workflows/helm-deploy-testkube-charts-stage.yaml
+++ b/.github/workflows/helm-deploy-testkube-charts-stage.yaml
@@ -183,9 +183,13 @@ jobs:
           set -x
           kubectl -n testkube delete test dashboard-e2e-tests --ignore-not-found=true
           kubectl apply -f ./test/dashboard-e2e/crd/crd.yaml
-      - name: Create staging testsuite
+      - name: (Re)create staging testsuite
         working-directory: ./testkube-repo
-        run: kubectl testkube create testsuite -f ./test/suites/staging-testsuite.json --name staging-testsuite
+        run: |-
+          # enabling debug mode
+          set -x
+          kubectl -n testkube delete testsuite staging-testsuite --ignore-not-found=true
+          kubectl testkube create testsuite -f ./test/suites/staging-testsuite.json --name staging-testsuite
       - name: Run staging testsuite
         run: kubectl testkube run testsuite staging-testsuite -f
 

--- a/.github/workflows/helm-deploy-testkube-charts-stage.yaml
+++ b/.github/workflows/helm-deploy-testkube-charts-stage.yaml
@@ -131,7 +131,7 @@ jobs:
   test_suite_run_stage:
     name: test suite for GKE cluster
     runs-on: ubuntu-latest
-    # needs: release_charts_if_image_updated
+    needs: release_charts_if_image_updated
     steps:
       # Setup gcloud CLI
       - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7

--- a/.github/workflows/helm-deploy-testkube-charts-stage.yaml
+++ b/.github/workflows/helm-deploy-testkube-charts-stage.yaml
@@ -155,35 +155,40 @@ jobs:
           cluster_name: ${{ env.GKE_CLUSTER_NAME_STAGE }}
           location: ${{ env.GKE_ZONE_STAGE }}
           credentials: ${{ secrets.GKE_SA_KEY }}
-      - name: Install testkube kubectl plugin
-        run: bash < <(curl -sSLf https://kubeshop.github.io/testkube/install.sh )
+      - name: Install testkube kubectl plugin and disable telemetry
+        run: bash < <(curl -sSLf https://kubeshop.github.io/testkube/install.sh ) && kubectl testkube disable telemetry
       - name: Checkout tests from main Testkube repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
         with:
           repository: kubeshop/testkube
+          ref: tests-cicd-testsuite # TODO: change branch to master before merge
           path: testkube-repo
-      - name: Testkube smoke tests - run script
+      - name: Executor tests - delete/create/schedule all executor tests
         working-directory: ./testkube-repo
-        run: chmod +x ./test/scripts/executor-tests/run.sh && ./test/scripts/executor-tests/run.sh -d -c -r -f -e soapui-smoke # delete, create, run, follow
+        run: chmod +x ./test/scripts/executor-tests/run.sh && ./test/scripts/executor-tests/run.sh -d -c -s # (delete, create, schedule) - don't execute
+      - name: (Re)create Postman Sanity test (with CLI)
+        working-directory: ./testkube-repo
+        run: |-
+          # enabling debug mode
+          set -x
+          kubectl -n testkube delete test sanity --ignore-not-found=true
+          kubectl -n testkube delete secret sanity-secrets --ignore-not-found=true
+          kubectl testkube create test -f ./test/postman/TestKube-Sanity.postman_collection.json --name sanity --type postman/collection -v api_uri=http://testkube-api-server:8088 -v test_api_uri=http://testkube-api-server:8088 -v test_type=postman/collection -v test_name=fill-me -v execution_name=fill-me
+      - name: Run Postman sanity tests
+        run: kubectl testkube run test sanity -f
+      - name: (Re)create Dashboard E2E tests (from CRD)
+        working-directory: ./testkube-repo
+        run: |-
+          # enabling debug mode
+          set -x
+          kubectl -n testkube delete test dashboard-e2e-tests --ignore-not-found=true
+          kubectl apply -f ./test/dashboard-e2e/crd/crd.yaml
+      - name: Create staging testsuite
+        working-directory: ./testkube-repo
+        run: kubectl testkube create testsuite -f ./test/suites/staging-testsuite.json --name staging-testsuite
+      - name: Run staging testsuite
+        run: kubectl testkube run testsuite staging-testsuite -f
 
-      # # Runnning test suite
-      # - name: Run test suite
-      #   run: |-
-      #     # enabling debug mode
-      #     set -x
-
-      #     # Installing testkube kubectl plugin:
-      #     # bash < <(curl -sSLf https://kubeshop.github.io/testkube/install.sh ) //TODO: remove - moved to separate step
-
-      #     # Downloading test suite:
-      #     # curl -LOs https://raw.githubusercontent.com/kubeshop/testkube/main/${{ env.POSTMAN_TEST_FILE_PATH }}/${{ env.POSTMAN_TEST_FILE_NANE }} //TODO: remove - repo checkout instead
-
-      #     # Running Test suite:
-      #     kubectl testkube disable telemetry
-      #     kubectl -n testkube delete test sanity || true
-      #     kubectl -n testkube delete secret sanity-secrets || true
-      #     kubectl testkube create test -f ./${{ env.POSTMAN_TEST_FILE_NANE }} --name sanity --type postman/collection -v api_uri=http://testkube-api-server:8088 -v test_api_uri=http://testkube-api-server:8088 -v test_type=postman/collection -v test_name=fill-me -v execution_name=fill-me
-      #     kubectl testkube run test sanity -f
 
   # notify_slack_if_test_suite_stage_succeeds:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/helm-deploy-testkube-charts-stage.yaml
+++ b/.github/workflows/helm-deploy-testkube-charts-stage.yaml
@@ -159,9 +159,9 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: kubeshop/testkube
-          path: testkube
+          path: testkube-repo
       - name: ls
-        run: ls -lah; cd testkube; ls -lah
+        run: echo "Main dir \n"; ls -lah; cd testkube-repo; echo "testkube-repo dir \n"; ls -lah
 
       # # Runnning test suite
       # - name: Run test suite

--- a/.github/workflows/helm-deploy-testkube-charts-stage.yaml
+++ b/.github/workflows/helm-deploy-testkube-charts-stage.yaml
@@ -2,19 +2,15 @@ name: Releasing Testkube Helm charts to Stage k8s Cluster.
 
 concurrency: staging_cluster
 
-# on:
-#   repository_dispatch:
-#     types:
-#       [
-#         trigger-workflow,
-#         trigger-workflow-dashboard,
-#         trigger-workflow-operator,
-#         trigger-workflow-executor,
-#       ]
-
 on:
-  pull_request:
-# TODO: remove - just for woflow tests
+  repository_dispatch:
+    types:
+      [
+        trigger-workflow,
+        trigger-workflow-dashboard,
+        trigger-workflow-operator,
+        trigger-workflow-executor,
+      ]
 
 env:
   PROJECT_ID: ${{ secrets.GKE_PROJECT }}
@@ -22,116 +18,115 @@ env:
   GKE_ZONE_STAGE: ${{ secrets.GKE_ZONE_STAGE }} # Add your cluster zone here.
   DEPLOYMENT_NAME: testkube # Add your deployment name here.
   ENV: stage
-  # POSTMAN_TEST_FILE_NANE: TestKube-Sanity.postman_collection.json //TODO: remove - not needed anymore
-  # POSTMAN_TEST_FILE_PATH: test/postman //TODO: remove - not needed anymore
+
 
 jobs:
-  # release_charts_if_image_updated:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         ref: ${{ github.event.client_payload.ref }}
+  release_charts_if_image_updated:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.client_payload.ref }}
 
-  #     - name: Configure Git
-  #       run: |
-  #         git config user.name "$GITHUB_ACTOR"
-  #         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-  #     - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
-  #       with:
-  #         service_account_key: ${{ secrets.GKE_SA_KEY }}
-  #         project_id: ${{ secrets.GKE_PROJECT }}
-  #     - run: |-
-  #         gcloud --quiet auth configure-docker
+      - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
+        with:
+          service_account_key: ${{ secrets.GKE_SA_KEY }}
+          project_id: ${{ secrets.GKE_PROJECT }}
+      - run: |-
+          gcloud --quiet auth configure-docker
 
-  #     - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
-  #       with:
-  #         cluster_name: ${{ env.GKE_CLUSTER_NAME_STAGE }}
-  #         location: ${{ env.GKE_ZONE_STAGE }}
-  #         credentials: ${{ secrets.GKE_SA_KEY }}
+      - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
+        with:
+          cluster_name: ${{ env.GKE_CLUSTER_NAME_STAGE }}
+          location: ${{ env.GKE_ZONE_STAGE }}
+          credentials: ${{ secrets.GKE_SA_KEY }}
 
-  #     - name: Install Helm
-  #       uses: azure/setup-helm@v1
-  #       with:
-  #         version: v3.4.0
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
 
-  #     - name: Modify executors.json file if any executor Docker image was updated
-  #       if: ${{ github.event.client_payload.image_tag_executor }}
-  #       run: |
-  #         export image_tag=${{ github.event.client_payload.image_tag_executor }}
-  #         export executor_name=${{ github.event.client_payload.executor_name }}
-  #         sed -i "s/\(.*\"image\":.*$executor_name.*\:\).*$/\1$image_tag\",/g" ./charts/testkube-api/executors.json
-  #         cat ./charts/testkube-api/executors.json
+      - name: Modify executors.json file if any executor Docker image was updated
+        if: ${{ github.event.client_payload.image_tag_executor }}
+        run: |
+          export image_tag=${{ github.event.client_payload.image_tag_executor }}
+          export executor_name=${{ github.event.client_payload.executor_name }}
+          sed -i "s/\(.*\"image\":.*$executor_name.*\:\).*$/\1$image_tag\",/g" ./charts/testkube-api/executors.json
+          cat ./charts/testkube-api/executors.json
 
-  #     - name: Installing repositories
-  #       run: |
-  #         helm repo add bitnami https://charts.bitnami.com/bitnami
+      - name: Installing repositories
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
 
-  #     - name: Get image tag of Testkube APi, Dashboard, Operator
-  #       id: vars
-  #       run: |
-  #         echo ::set-output name=api_image_tag::$(kubectl get deployment testkube-api-server -o=jsonpath='{$.spec.template.spec.containers[:1].image}' -n ${{ env.DEPLOYMENT_NAME }} | awk -F':' '{print $2}') || exit 1
-  #         echo ::set-output name=operator_image_tag::$(kubectl get deployment testkube-operator-controller-manager -o=jsonpath='{$.spec.template.spec.containers[1].image}' -n ${{ env.DEPLOYMENT_NAME }} | awk -F':' '{print $2}') || exit 1
-  #         echo ::set-output name=dashboard_image_tag::$(kubectl get deployment testkube-dashboard -o=jsonpath='{$.spec.template.spec.containers[:1].image}' -n ${{ env.DEPLOYMENT_NAME }} | awk -F':' '{print $2}') || exit 1
+      - name: Get image tag of Testkube APi, Dashboard, Operator
+        id: vars
+        run: |
+          echo ::set-output name=api_image_tag::$(kubectl get deployment testkube-api-server -o=jsonpath='{$.spec.template.spec.containers[:1].image}' -n ${{ env.DEPLOYMENT_NAME }} | awk -F':' '{print $2}') || exit 1
+          echo ::set-output name=operator_image_tag::$(kubectl get deployment testkube-operator-controller-manager -o=jsonpath='{$.spec.template.spec.containers[1].image}' -n ${{ env.DEPLOYMENT_NAME }} | awk -F':' '{print $2}') || exit 1
+          echo ::set-output name=dashboard_image_tag::$(kubectl get deployment testkube-dashboard -o=jsonpath='{$.spec.template.spec.containers[:1].image}' -n ${{ env.DEPLOYMENT_NAME }} | awk -F':' '{print $2}') || exit 1
 
-  #     - name: Deploy if Executors' image is update
-  #       if: ${{ github.event.client_payload.image_tag_executor }}
-  #       run: |
-  #         helm dependency update ./charts/testkube
-  #         helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml  --set testkube-api.image.tag=${{ steps.vars.outputs.api_image_tag }} --set testkube-operator.image.tag=${{ steps.vars.outputs.operator_image_tag }} --set testkube-dashboard.image.tag=${{ steps.vars.outputs.dashboard_image_tag }}
+      - name: Deploy if Executors' image is update
+        if: ${{ github.event.client_payload.image_tag_executor }}
+        run: |
+          helm dependency update ./charts/testkube
+          helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml  --set testkube-api.image.tag=${{ steps.vars.outputs.api_image_tag }} --set testkube-operator.image.tag=${{ steps.vars.outputs.operator_image_tag }} --set testkube-dashboard.image.tag=${{ steps.vars.outputs.dashboard_image_tag }}
 
-  #     - name: Deploy if Testkube API image is updated
-  #       if: ${{ github.event.client_payload.image_tag }}
-  #       run: |
-  #         helm dependency update ./charts/testkube
-  #         helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml --set testkube-api.image.tag=${{ github.event.client_payload.image_tag }} --set testkube-operator.image.tag=${{ steps.vars.outputs.operator_image_tag }} --set testkube-dashboard.image.tag=${{ steps.vars.outputs.dashboard_image_tag }}
+      - name: Deploy if Testkube API image is updated
+        if: ${{ github.event.client_payload.image_tag }}
+        run: |
+          helm dependency update ./charts/testkube
+          helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml --set testkube-api.image.tag=${{ github.event.client_payload.image_tag }} --set testkube-operator.image.tag=${{ steps.vars.outputs.operator_image_tag }} --set testkube-dashboard.image.tag=${{ steps.vars.outputs.dashboard_image_tag }}
 
-  #     - name: Deploy if Testkube Dashboard image is updated
-  #       if: ${{ github.event.client_payload.image_tag_dashboard }}
-  #       run: |
-  #         helm dependency update ./charts/testkube
-  #         helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml --set testkube-dashboard.image.tag=${{ github.event.client_payload.image_tag_dashboard }} --set testkube-operator.image.tag=${{ steps.vars.outputs.operator_image_tag }} --set testkube-api.image.tag=${{ steps.vars.outputs.api_image_tag }}
+      - name: Deploy if Testkube Dashboard image is updated
+        if: ${{ github.event.client_payload.image_tag_dashboard }}
+        run: |
+          helm dependency update ./charts/testkube
+          helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml --set testkube-dashboard.image.tag=${{ github.event.client_payload.image_tag_dashboard }} --set testkube-operator.image.tag=${{ steps.vars.outputs.operator_image_tag }} --set testkube-api.image.tag=${{ steps.vars.outputs.api_image_tag }}
 
-  #     - name: Deploy if Testkube Operator image is updated
-  #       if: ${{ github.event.client_payload.image_tag_operator }}
-  #       run: |
-  #         helm dependency update ./charts/testkube
-  #         helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml --set testkube-operator.image.tag=${{ github.event.client_payload.image_tag_operator }} --set testkube-dashboard.image.tag=${{ steps.vars.outputs.dashboard_image_tag }} --set testkube-api.image.tag=${{ steps.vars.outputs.api_image_tag }}
+      - name: Deploy if Testkube Operator image is updated
+        if: ${{ github.event.client_payload.image_tag_operator }}
+        run: |
+          helm dependency update ./charts/testkube
+          helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml --set testkube-operator.image.tag=${{ github.event.client_payload.image_tag_operator }} --set testkube-dashboard.image.tag=${{ steps.vars.outputs.dashboard_image_tag }} --set testkube-api.image.tag=${{ steps.vars.outputs.api_image_tag }}
 
-  # notify_slack_if_deploy_stage_succeeds:
-  #   runs-on: ubuntu-latest
-  #   needs: release_charts_if_image_updated
-  #   steps:
-  #     - name: Slack Notification if the helm release deployment to ${{ env.ENV }} GKS succeeded.
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: testkube-logs
-  #         SLACK_COLOR: ${{ needs.release_charts_if_image_updated.result }} # or a specific color like 'good' or '#ff00ff'
-  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
-  #         SLACK_TITLE: Helm chart release successfully deployed into ${{ secrets.GKE_CLUSTER_NAME_STAGE }} GKE :party_blob:!
-  #         SLACK_USERNAME: GitHub
-  #         SLACK_LINK_NAMES: true
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #         SLACK_FOOTER: "Kubeshop --> TestKube"
+  notify_slack_if_deploy_stage_succeeds:
+    runs-on: ubuntu-latest
+    needs: release_charts_if_image_updated
+    steps:
+      - name: Slack Notification if the helm release deployment to ${{ env.ENV }} GKS succeeded.
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.release_charts_if_image_updated.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Helm chart release successfully deployed into ${{ secrets.GKE_CLUSTER_NAME_STAGE }} GKE :party_blob:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  # notify_slack_if_deploy_stage_failed:
-  #   runs-on: ubuntu-latest
-  #   needs: release_charts_if_image_updated
-  #   if: always() && (needs.release_charts_if_image_updated.result == 'failure')
-  #   steps:
-  #     - name: Slack Notification if the helm release deployment to ${{ env.ENV }} GKS failed.
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: testkube-logs
-  #         SLACK_COLOR: ${{ needs.release_charts_if_image_updated.result }} # or a specific color like 'good' or '#ff00ff'
-  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
-  #         SLACK_TITLE: Helm chart release failed to deploy into ${{ secrets.GKE_CLUSTER_NAME_STAGE }} GKE! :boom:!
-  #         SLACK_USERNAME: GitHub
-  #         SLACK_LINK_NAMES: true
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #         SLACK_FOOTER: "Kubeshop --> TestKube"
+  notify_slack_if_deploy_stage_failed:
+    runs-on: ubuntu-latest
+    needs: release_charts_if_image_updated
+    if: always() && (needs.release_charts_if_image_updated.result == 'failure')
+    steps:
+      - name: Slack Notification if the helm release deployment to ${{ env.ENV }} GKS failed.
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.release_charts_if_image_updated.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Helm chart release failed to deploy into ${{ secrets.GKE_CLUSTER_NAME_STAGE }} GKE! :boom:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"
 
   test_suite_run_stage:
     name: test suite for GKE cluster
@@ -155,17 +150,20 @@ jobs:
           cluster_name: ${{ env.GKE_CLUSTER_NAME_STAGE }}
           location: ${{ env.GKE_ZONE_STAGE }}
           credentials: ${{ secrets.GKE_SA_KEY }}
+
       - name: Install testkube kubectl plugin and disable telemetry
         run: bash < <(curl -sSLf https://kubeshop.github.io/testkube/install.sh ) && kubectl testkube disable telemetry
+
       - name: Checkout tests from main Testkube repo
         uses: actions/checkout@v3
         with:
           repository: kubeshop/testkube
-          ref: tests-cicd-testsuite # TODO: change branch to master before merge
           path: testkube-repo
+
       - name: Executor tests - delete/create/schedule all executor tests
         working-directory: ./testkube-repo
         run: chmod +x ./test/scripts/executor-tests/run.sh && ./test/scripts/executor-tests/run.sh -d -c -s # (delete, create, schedule) - don't execute
+
       - name: (Re)create Postman Sanity test (with CLI)
         working-directory: ./testkube-repo
         run: |-
@@ -174,8 +172,10 @@ jobs:
           kubectl -n testkube delete test sanity --ignore-not-found=true
           kubectl -n testkube delete secret sanity-secrets --ignore-not-found=true
           kubectl testkube create test -f ./test/postman/TestKube-Sanity.postman_collection.json --name sanity --type postman/collection -v api_uri=http://testkube-api-server:8088 -v test_api_uri=http://testkube-api-server:8088 -v test_type=postman/collection -v test_name=fill-me -v execution_name=fill-me
+
       - name: Run Postman sanity tests
         run: kubectl testkube run test sanity -f
+
       - name: (Re)create Dashboard E2E tests (from CRD)
         working-directory: ./testkube-repo
         run: |-
@@ -183,6 +183,7 @@ jobs:
           set -x
           kubectl -n testkube delete test dashboard-e2e-tests --ignore-not-found=true
           kubectl apply -f ./test/dashboard-e2e/crd/crd.yaml
+
       - name: (Re)create staging testsuite
         working-directory: ./testkube-repo
         run: |-
@@ -190,39 +191,39 @@ jobs:
           set -x
           kubectl -n testkube delete testsuite staging-testsuite --ignore-not-found=true
           kubectl testkube create testsuite -f ./test/suites/staging-testsuite.json --name staging-testsuite
+
       - name: Run staging testsuite
         run: kubectl testkube run testsuite staging-testsuite -f
 
+  notify_slack_if_test_suite_stage_succeeds:
+    runs-on: ubuntu-latest
+    needs: test_suite_run_stage
+    steps:
+      - name: Slack Notification if the test suite run on STAGE GKS succeeded.
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.test_suite_run_stage.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Test suite successfully run against ${{ secrets.GKE_CLUSTER_NAME_STAGE }} GKE :party_blob:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  # notify_slack_if_test_suite_stage_succeeds:
-  #   runs-on: ubuntu-latest
-  #   needs: test_suite_run_stage
-  #   steps:
-  #     - name: Slack Notification if the test suite run on STAGE GKS succeeded.
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: testkube-logs
-  #         SLACK_COLOR: ${{ needs.test_suite_run_stage.result }} # or a specific color like 'good' or '#ff00ff'
-  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
-  #         SLACK_TITLE: Test suite successfully run against ${{ secrets.GKE_CLUSTER_NAME_STAGE }} GKE :party_blob:!
-  #         SLACK_USERNAME: GitHub
-  #         SLACK_LINK_NAMES: true
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #         SLACK_FOOTER: "Kubeshop --> TestKube"
-
-  # notify_slack_if_test_suite_failed:
-  #   runs-on: ubuntu-latest
-  #   needs: test_suite_run_stage
-  #   if: always() && (needs.test_suite_run_stage.result == 'failure')
-  #   steps:
-  #     - name: Slack Notification if the test suite run on ${{ env.ENV }} GKS failed.
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: testkube-logs
-  #         SLACK_COLOR: ${{ needs.test_suite_run_stage.result }} # or a specific color like 'good' or '#ff00ff'
-  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
-  #         SLACK_TITLE: Test suite FAILED to run on ${{ secrets.GKE_CLUSTER_NAME_STAGE }} GKE! :boom:!
-  #         SLACK_USERNAME: GitHub
-  #         SLACK_LINK_NAMES: true
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #         SLACK_FOOTER: "Kubeshop --> TestKube"
+  notify_slack_if_test_suite_failed:
+    runs-on: ubuntu-latest
+    needs: test_suite_run_stage
+    if: always() && (needs.test_suite_run_stage.result == 'failure')
+    steps:
+      - name: Slack Notification if the test suite run on ${{ env.ENV }} GKS failed.
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.test_suite_run_stage.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Test suite FAILED to run on ${{ secrets.GKE_CLUSTER_NAME_STAGE }} GKE! :boom:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"

--- a/.github/workflows/helm-deploy-testkube-charts-stage.yaml
+++ b/.github/workflows/helm-deploy-testkube-charts-stage.yaml
@@ -160,25 +160,27 @@ jobs:
         with:
           repository: kubeshop/testkube
           path: testkube
+      - name: ls
+        run: ls -lah; cd testkube; ls -lah
 
-      # Runnning test suite
-      - name: Run test suite
-        run: |-
-          # enabling debug mode
-          set -x
+      # # Runnning test suite
+      # - name: Run test suite
+      #   run: |-
+      #     # enabling debug mode
+      #     set -x
 
-          # Installing testkube kubectl plugin:
-          bash < <(curl -sSLf https://kubeshop.github.io/testkube/install.sh )
+      #     # Installing testkube kubectl plugin:
+      #     bash < <(curl -sSLf https://kubeshop.github.io/testkube/install.sh )
 
-          # Downloading test suite:
-          curl -LOs https://raw.githubusercontent.com/kubeshop/testkube/main/${{ env.POSTMAN_TEST_FILE_PATH }}/${{ env.POSTMAN_TEST_FILE_NANE }}
+      #     # Downloading test suite:
+      #     curl -LOs https://raw.githubusercontent.com/kubeshop/testkube/main/${{ env.POSTMAN_TEST_FILE_PATH }}/${{ env.POSTMAN_TEST_FILE_NANE }}
 
-          # Running Test suite:
-          kubectl testkube disable telemetry
-          kubectl -n testkube delete test sanity || true
-          kubectl -n testkube delete secret sanity-secrets || true
-          kubectl testkube create test -f ./${{ env.POSTMAN_TEST_FILE_NANE }} --name sanity --type postman/collection -v api_uri=http://testkube-api-server:8088 -v test_api_uri=http://testkube-api-server:8088 -v test_type=postman/collection -v test_name=fill-me -v execution_name=fill-me
-          kubectl testkube run test sanity -f
+      #     # Running Test suite:
+      #     kubectl testkube disable telemetry
+      #     kubectl -n testkube delete test sanity || true
+      #     kubectl -n testkube delete secret sanity-secrets || true
+      #     kubectl testkube create test -f ./${{ env.POSTMAN_TEST_FILE_NANE }} --name sanity --type postman/collection -v api_uri=http://testkube-api-server:8088 -v test_api_uri=http://testkube-api-server:8088 -v test_type=postman/collection -v test_name=fill-me -v execution_name=fill-me
+      #     kubectl testkube run test sanity -f
 
   # notify_slack_if_test_suite_stage_succeeds:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/helm-deploy-testkube-charts-stage.yaml
+++ b/.github/workflows/helm-deploy-testkube-charts-stage.yaml
@@ -2,15 +2,19 @@ name: Releasing Testkube Helm charts to Stage k8s Cluster.
 
 concurrency: staging_cluster
 
+# on:
+#   repository_dispatch:
+#     types:
+#       [
+#         trigger-workflow,
+#         trigger-workflow-dashboard,
+#         trigger-workflow-operator,
+#         trigger-workflow-executor,
+#       ]
+
 on:
-  repository_dispatch:
-    types:
-      [
-        trigger-workflow,
-        trigger-workflow-dashboard,
-        trigger-workflow-operator,
-        trigger-workflow-executor,
-      ]
+  pull_request:
+# TODO: remove - just for woflow tests
 
 env:
   PROJECT_ID: ${{ secrets.GKE_PROJECT }}
@@ -22,117 +26,117 @@ env:
   POSTMAN_TEST_FILE_PATH: test/postman
 
 jobs:
-  release_charts_if_image_updated:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.client_payload.ref }}
+  # release_charts_if_image_updated:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         ref: ${{ github.event.client_payload.ref }}
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+  #     - name: Configure Git
+  #       run: |
+  #         git config user.name "$GITHUB_ACTOR"
+  #         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
-        with:
-          service_account_key: ${{ secrets.GKE_SA_KEY }}
-          project_id: ${{ secrets.GKE_PROJECT }}
-      - run: |-
-          gcloud --quiet auth configure-docker
+  #     - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
+  #       with:
+  #         service_account_key: ${{ secrets.GKE_SA_KEY }}
+  #         project_id: ${{ secrets.GKE_PROJECT }}
+  #     - run: |-
+  #         gcloud --quiet auth configure-docker
 
-      - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
-        with:
-          cluster_name: ${{ env.GKE_CLUSTER_NAME_STAGE }}
-          location: ${{ env.GKE_ZONE_STAGE }}
-          credentials: ${{ secrets.GKE_SA_KEY }}
+  #     - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
+  #       with:
+  #         cluster_name: ${{ env.GKE_CLUSTER_NAME_STAGE }}
+  #         location: ${{ env.GKE_ZONE_STAGE }}
+  #         credentials: ${{ secrets.GKE_SA_KEY }}
 
-      - name: Install Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.4.0
+  #     - name: Install Helm
+  #       uses: azure/setup-helm@v1
+  #       with:
+  #         version: v3.4.0
 
-      - name: Modify executors.json file if any executor Docker image was updated
-        if: ${{ github.event.client_payload.image_tag_executor }}
-        run: |
-          export image_tag=${{ github.event.client_payload.image_tag_executor }}
-          export executor_name=${{ github.event.client_payload.executor_name }}
-          sed -i "s/\(.*\"image\":.*$executor_name.*\:\).*$/\1$image_tag\",/g" ./charts/testkube-api/executors.json
-          cat ./charts/testkube-api/executors.json
+  #     - name: Modify executors.json file if any executor Docker image was updated
+  #       if: ${{ github.event.client_payload.image_tag_executor }}
+  #       run: |
+  #         export image_tag=${{ github.event.client_payload.image_tag_executor }}
+  #         export executor_name=${{ github.event.client_payload.executor_name }}
+  #         sed -i "s/\(.*\"image\":.*$executor_name.*\:\).*$/\1$image_tag\",/g" ./charts/testkube-api/executors.json
+  #         cat ./charts/testkube-api/executors.json
 
-      - name: Installing repositories
-        run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
+  #     - name: Installing repositories
+  #       run: |
+  #         helm repo add bitnami https://charts.bitnami.com/bitnami
 
-      - name: Get image tag of Testkube APi, Dashboard, Operator
-        id: vars
-        run: |
-          echo ::set-output name=api_image_tag::$(kubectl get deployment testkube-api-server -o=jsonpath='{$.spec.template.spec.containers[:1].image}' -n ${{ env.DEPLOYMENT_NAME }} | awk -F':' '{print $2}') || exit 1
-          echo ::set-output name=operator_image_tag::$(kubectl get deployment testkube-operator-controller-manager -o=jsonpath='{$.spec.template.spec.containers[1].image}' -n ${{ env.DEPLOYMENT_NAME }} | awk -F':' '{print $2}') || exit 1
-          echo ::set-output name=dashboard_image_tag::$(kubectl get deployment testkube-dashboard -o=jsonpath='{$.spec.template.spec.containers[:1].image}' -n ${{ env.DEPLOYMENT_NAME }} | awk -F':' '{print $2}') || exit 1
+  #     - name: Get image tag of Testkube APi, Dashboard, Operator
+  #       id: vars
+  #       run: |
+  #         echo ::set-output name=api_image_tag::$(kubectl get deployment testkube-api-server -o=jsonpath='{$.spec.template.spec.containers[:1].image}' -n ${{ env.DEPLOYMENT_NAME }} | awk -F':' '{print $2}') || exit 1
+  #         echo ::set-output name=operator_image_tag::$(kubectl get deployment testkube-operator-controller-manager -o=jsonpath='{$.spec.template.spec.containers[1].image}' -n ${{ env.DEPLOYMENT_NAME }} | awk -F':' '{print $2}') || exit 1
+  #         echo ::set-output name=dashboard_image_tag::$(kubectl get deployment testkube-dashboard -o=jsonpath='{$.spec.template.spec.containers[:1].image}' -n ${{ env.DEPLOYMENT_NAME }} | awk -F':' '{print $2}') || exit 1
 
-      - name: Deploy if Executors' image is update
-        if: ${{ github.event.client_payload.image_tag_executor }}
-        run: |
-          helm dependency update ./charts/testkube
-          helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml  --set testkube-api.image.tag=${{ steps.vars.outputs.api_image_tag }} --set testkube-operator.image.tag=${{ steps.vars.outputs.operator_image_tag }} --set testkube-dashboard.image.tag=${{ steps.vars.outputs.dashboard_image_tag }}
+  #     - name: Deploy if Executors' image is update
+  #       if: ${{ github.event.client_payload.image_tag_executor }}
+  #       run: |
+  #         helm dependency update ./charts/testkube
+  #         helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml  --set testkube-api.image.tag=${{ steps.vars.outputs.api_image_tag }} --set testkube-operator.image.tag=${{ steps.vars.outputs.operator_image_tag }} --set testkube-dashboard.image.tag=${{ steps.vars.outputs.dashboard_image_tag }}
 
-      - name: Deploy if Testkube API image is updated
-        if: ${{ github.event.client_payload.image_tag }}
-        run: |
-          helm dependency update ./charts/testkube
-          helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml --set testkube-api.image.tag=${{ github.event.client_payload.image_tag }} --set testkube-operator.image.tag=${{ steps.vars.outputs.operator_image_tag }} --set testkube-dashboard.image.tag=${{ steps.vars.outputs.dashboard_image_tag }}
+  #     - name: Deploy if Testkube API image is updated
+  #       if: ${{ github.event.client_payload.image_tag }}
+  #       run: |
+  #         helm dependency update ./charts/testkube
+  #         helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml --set testkube-api.image.tag=${{ github.event.client_payload.image_tag }} --set testkube-operator.image.tag=${{ steps.vars.outputs.operator_image_tag }} --set testkube-dashboard.image.tag=${{ steps.vars.outputs.dashboard_image_tag }}
 
-      - name: Deploy if Testkube Dashboard image is updated
-        if: ${{ github.event.client_payload.image_tag_dashboard }}
-        run: |
-          helm dependency update ./charts/testkube
-          helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml --set testkube-dashboard.image.tag=${{ github.event.client_payload.image_tag_dashboard }} --set testkube-operator.image.tag=${{ steps.vars.outputs.operator_image_tag }} --set testkube-api.image.tag=${{ steps.vars.outputs.api_image_tag }}
+  #     - name: Deploy if Testkube Dashboard image is updated
+  #       if: ${{ github.event.client_payload.image_tag_dashboard }}
+  #       run: |
+  #         helm dependency update ./charts/testkube
+  #         helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml --set testkube-dashboard.image.tag=${{ github.event.client_payload.image_tag_dashboard }} --set testkube-operator.image.tag=${{ steps.vars.outputs.operator_image_tag }} --set testkube-api.image.tag=${{ steps.vars.outputs.api_image_tag }}
 
-      - name: Deploy if Testkube Operator image is updated
-        if: ${{ github.event.client_payload.image_tag_operator }}
-        run: |
-          helm dependency update ./charts/testkube
-          helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml --set testkube-operator.image.tag=${{ github.event.client_payload.image_tag_operator }} --set testkube-dashboard.image.tag=${{ steps.vars.outputs.dashboard_image_tag }} --set testkube-api.image.tag=${{ steps.vars.outputs.api_image_tag }}
+  #     - name: Deploy if Testkube Operator image is updated
+  #       if: ${{ github.event.client_payload.image_tag_operator }}
+  #       run: |
+  #         helm dependency update ./charts/testkube
+  #         helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml --set testkube-operator.image.tag=${{ github.event.client_payload.image_tag_operator }} --set testkube-dashboard.image.tag=${{ steps.vars.outputs.dashboard_image_tag }} --set testkube-api.image.tag=${{ steps.vars.outputs.api_image_tag }}
 
-  notify_slack_if_deploy_stage_succeeds:
-    runs-on: ubuntu-latest
-    needs: release_charts_if_image_updated
-    steps:
-      - name: Slack Notification if the helm release deployment to ${{ env.ENV }} GKS succeeded.
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: testkube-logs
-          SLACK_COLOR: ${{ needs.release_charts_if_image_updated.result }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_TITLE: Helm chart release successfully deployed into ${{ secrets.GKE_CLUSTER_NAME_STAGE }} GKE :party_blob:!
-          SLACK_USERNAME: GitHub
-          SLACK_LINK_NAMES: true
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_FOOTER: "Kubeshop --> TestKube"
+  # notify_slack_if_deploy_stage_succeeds:
+  #   runs-on: ubuntu-latest
+  #   needs: release_charts_if_image_updated
+  #   steps:
+  #     - name: Slack Notification if the helm release deployment to ${{ env.ENV }} GKS succeeded.
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_CHANNEL: testkube-logs
+  #         SLACK_COLOR: ${{ needs.release_charts_if_image_updated.result }} # or a specific color like 'good' or '#ff00ff'
+  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
+  #         SLACK_TITLE: Helm chart release successfully deployed into ${{ secrets.GKE_CLUSTER_NAME_STAGE }} GKE :party_blob:!
+  #         SLACK_USERNAME: GitHub
+  #         SLACK_LINK_NAMES: true
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #         SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  notify_slack_if_deploy_stage_failed:
-    runs-on: ubuntu-latest
-    needs: release_charts_if_image_updated
-    if: always() && (needs.release_charts_if_image_updated.result == 'failure')
-    steps:
-      - name: Slack Notification if the helm release deployment to ${{ env.ENV }} GKS failed.
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: testkube-logs
-          SLACK_COLOR: ${{ needs.release_charts_if_image_updated.result }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_TITLE: Helm chart release failed to deploy into ${{ secrets.GKE_CLUSTER_NAME_STAGE }} GKE! :boom:!
-          SLACK_USERNAME: GitHub
-          SLACK_LINK_NAMES: true
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_FOOTER: "Kubeshop --> TestKube"
+  # notify_slack_if_deploy_stage_failed:
+  #   runs-on: ubuntu-latest
+  #   needs: release_charts_if_image_updated
+  #   if: always() && (needs.release_charts_if_image_updated.result == 'failure')
+  #   steps:
+  #     - name: Slack Notification if the helm release deployment to ${{ env.ENV }} GKS failed.
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_CHANNEL: testkube-logs
+  #         SLACK_COLOR: ${{ needs.release_charts_if_image_updated.result }} # or a specific color like 'good' or '#ff00ff'
+  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
+  #         SLACK_TITLE: Helm chart release failed to deploy into ${{ secrets.GKE_CLUSTER_NAME_STAGE }} GKE! :boom:!
+  #         SLACK_USERNAME: GitHub
+  #         SLACK_LINK_NAMES: true
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #         SLACK_FOOTER: "Kubeshop --> TestKube"
 
   test_suite_run_stage:
     name: test suite for GKE cluster
     runs-on: ubuntu-latest
-    needs: release_charts_if_image_updated
+    # needs: release_charts_if_image_updated
     steps:
       # Setup gcloud CLI
       - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
@@ -151,6 +155,11 @@ jobs:
           cluster_name: ${{ env.GKE_CLUSTER_NAME_STAGE }}
           location: ${{ env.GKE_ZONE_STAGE }}
           credentials: ${{ secrets.GKE_SA_KEY }}
+      - name: Checkout tests from main Testkube repo
+        uses: actions/checkout@master
+        with:
+          repository: kubeshop/testkube
+          path: testkube
 
       # Runnning test suite
       - name: Run test suite
@@ -171,35 +180,35 @@ jobs:
           kubectl testkube create test -f ./${{ env.POSTMAN_TEST_FILE_NANE }} --name sanity --type postman/collection -v api_uri=http://testkube-api-server:8088 -v test_api_uri=http://testkube-api-server:8088 -v test_type=postman/collection -v test_name=fill-me -v execution_name=fill-me
           kubectl testkube run test sanity -f
 
-  notify_slack_if_test_suite_stage_succeeds:
-    runs-on: ubuntu-latest
-    needs: test_suite_run_stage
-    steps:
-      - name: Slack Notification if the test suite run on STAGE GKS succeeded.
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: testkube-logs
-          SLACK_COLOR: ${{ needs.test_suite_run_stage.result }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_TITLE: Test suite successfully run against ${{ secrets.GKE_CLUSTER_NAME_STAGE }} GKE :party_blob:!
-          SLACK_USERNAME: GitHub
-          SLACK_LINK_NAMES: true
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_FOOTER: "Kubeshop --> TestKube"
+  # notify_slack_if_test_suite_stage_succeeds:
+  #   runs-on: ubuntu-latest
+  #   needs: test_suite_run_stage
+  #   steps:
+  #     - name: Slack Notification if the test suite run on STAGE GKS succeeded.
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_CHANNEL: testkube-logs
+  #         SLACK_COLOR: ${{ needs.test_suite_run_stage.result }} # or a specific color like 'good' or '#ff00ff'
+  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
+  #         SLACK_TITLE: Test suite successfully run against ${{ secrets.GKE_CLUSTER_NAME_STAGE }} GKE :party_blob:!
+  #         SLACK_USERNAME: GitHub
+  #         SLACK_LINK_NAMES: true
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #         SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  notify_slack_if_test_suite_failed:
-    runs-on: ubuntu-latest
-    needs: test_suite_run_stage
-    if: always() && (needs.test_suite_run_stage.result == 'failure')
-    steps:
-      - name: Slack Notification if the test suite run on ${{ env.ENV }} GKS failed.
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: testkube-logs
-          SLACK_COLOR: ${{ needs.test_suite_run_stage.result }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_TITLE: Test suite FAILED to run on ${{ secrets.GKE_CLUSTER_NAME_STAGE }} GKE! :boom:!
-          SLACK_USERNAME: GitHub
-          SLACK_LINK_NAMES: true
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_FOOTER: "Kubeshop --> TestKube"
+  # notify_slack_if_test_suite_failed:
+  #   runs-on: ubuntu-latest
+  #   needs: test_suite_run_stage
+  #   if: always() && (needs.test_suite_run_stage.result == 'failure')
+  #   steps:
+  #     - name: Slack Notification if the test suite run on ${{ env.ENV }} GKS failed.
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_CHANNEL: testkube-logs
+  #         SLACK_COLOR: ${{ needs.test_suite_run_stage.result }} # or a specific color like 'good' or '#ff00ff'
+  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
+  #         SLACK_TITLE: Test suite FAILED to run on ${{ secrets.GKE_CLUSTER_NAME_STAGE }} GKE! :boom:!
+  #         SLACK_USERNAME: GitHub
+  #         SLACK_LINK_NAMES: true
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #         SLACK_FOOTER: "Kubeshop --> TestKube"

--- a/.github/workflows/helm-deploy-testkube-charts-stage.yaml
+++ b/.github/workflows/helm-deploy-testkube-charts-stage.yaml
@@ -164,7 +164,7 @@ jobs:
           path: testkube-repo
       - name: Testkube smoke tests - run script
         working-directory: ./testkube-repo
-        run: chmod +x ./test/scripts/executor-tests/run.sh && ./test/scripts/executor-tests/run.sh -d -c -s -e soapui-smoke
+        run: chmod +x ./test/scripts/executor-tests/run.sh && ./test/scripts/executor-tests/run.sh -d -c -r -f -e soapui-smoke # delete, create, run, follow
 
       # # Runnning test suite
       # - name: Run test suite


### PR DESCRIPTION
- tests checkout from main `testkube` repo
- executor tests - test delete, create, and schedule checks for all executor tests
- (re)creating Postman sanity test (with testkube cli) + running `Test` - updated
- (re)creating Dashboard E2E tests (from CRD)
- Running Staging testsuite
- Postman and Dashboard tests creation is separated on purpose to check creation from CLI and CRD
- Postman Test isn't included in Staging testsuite to check both running a single test and testsuite
- kubectl delete changed from `|| true` to `--ignore-not-found=true`


Merge after:
- [x] **PR with `staging-testsuite`: https://github.com/kubeshop/testkube/pull/2692**
- [x] Fix for testsuite follow (`-f`): https://github.com/kubeshop/testkube/pull/2694