### PR TITLE
chore: Testkube tests - dev/demo workflow

### DIFF
--- a/.github/workflows/helm-releaser-testkube-charts.yaml
+++ b/.github/workflows/helm-releaser-testkube-charts.yaml
@@ -1,226 +1,227 @@
 name: Releasing Helm charts.
 
+# on:
+#   push:
+#     paths:
+#       - "charts/testkube**"
+#       - "charts/testkube-api/**"
+#     branches:
+#       - main
+
 on:
-  push:
-    paths:
-      - "charts/testkube**"
-      - "charts/testkube-api/**"
-    branches:
-      - main
+  pull_request:
 
 env:
   PROJECT_ID: ${{ secrets.GKE_PROJECT }}
   GKE_CLUSTER_NAME_DEV: ${{ secrets.GKE_CLUSTER_NAME_DEV }} # Add your cluster name here.
   GKE_ZONE_DEV: ${{ secrets.GKE_ZONE_DEV }} # Add your cluster zone here.
   DEPLOYMENT_NAME: testkube # Add your deployment name here.
-  POSTMAN_TEST_FILE_NANE: TestKube-Sanity.postman_collection.json
-  POSTMAN_TEST_FILE_PATH: test/postman
 
 jobs:
-  release_charts:
-    runs-on: ubuntu-latest
+  # release_charts:
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+  #     - name: Configure Git
+  #       run: |
+  #         git config user.name "$GITHUB_ACTOR"
+  #         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Install Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.4.0
+  #     - name: Install Helm
+  #       uses: azure/setup-helm@v1
+  #       with:
+  #         version: v3.4.0
 
-      - name: Installing repositories
-        run: |
-          helm repo add helm-charts https://kubeshop.github.io/helm-charts
-          helm repo add bitnami https://charts.bitnami.com/bitnami
+  #     - name: Installing repositories
+  #       run: |
+  #         helm repo add helm-charts https://kubeshop.github.io/helm-charts
+  #         helm repo add bitnami https://charts.bitnami.com/bitnami
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
-        with:
-          charts_dir: charts
-        env:
-          CR_TOKEN: "${{ secrets.CI_BOT_TOKEN }}"
-          CR_SKIP_EXISTING: true
+  #     - name: Run chart-releaser
+  #       uses: helm/chart-releaser-action@v1.2.1
+  #       with:
+  #         charts_dir: charts
+  #       env:
+  #         CR_TOKEN: "${{ secrets.CI_BOT_TOKEN }}"
+  #         CR_SKIP_EXISTING: true
 
-  notify_slack_if_helm_chart_release_fails:
-    runs-on: ubuntu-latest
-    needs: release_charts
-    if: always() && (needs.release_charts.result == 'failure')
-    steps:
-      - name: Slack Notification if Helm Release action failed
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: testkube-logs
-          SLACK_COLOR: ${{ needs.release_charts.result }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_TITLE: Helm Chart release action failed :boom:!
-          SLACK_USERNAME: GitHub
-          SLACK_LINK_NAMES: true
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_FOOTER: "Kubeshop --> TestKube"
+  # notify_slack_if_helm_chart_release_fails:
+  #   runs-on: ubuntu-latest
+  #   needs: release_charts
+  #   if: always() && (needs.release_charts.result == 'failure')
+  #   steps:
+  #     - name: Slack Notification if Helm Release action failed
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_CHANNEL: testkube-logs
+  #         SLACK_COLOR: ${{ needs.release_charts.result }} # or a specific color like 'good' or '#ff00ff'
+  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
+  #         SLACK_TITLE: Helm Chart release action failed :boom:!
+  #         SLACK_USERNAME: GitHub
+  #         SLACK_LINK_NAMES: true
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #         SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  refreshing_gh_pages:
-    needs: release_charts
-    runs-on: ubuntu-latest
-    steps:
-      - name: Triggering refresh for GH-pages to make just released charts available
-        run: |
-          curl -s --fail --request POST \
-            --url https://api.github.com/repos/kubeshop/helm-charts/pages/builds \
-            --header "Authorization: Bearer $USER_TOKEN"
-        env:
-          # You must create a personal token with repo access as GitHub does
-          # not yet support server-to-server page builds.
-          USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+  # refreshing_gh_pages:
+  #   needs: release_charts
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Triggering refresh for GH-pages to make just released charts available
+  #       run: |
+  #         curl -s --fail --request POST \
+  #           --url https://api.github.com/repos/kubeshop/helm-charts/pages/builds \
+  #           --header "Authorization: Bearer $USER_TOKEN"
+  #       env:
+  #         # You must create a personal token with repo access as GitHub does
+  #         # not yet support server-to-server page builds.
+  #         USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
 
-  checking_that_ghpages_updated:
-    needs: refreshing_gh_pages
-    runs-on: ubuntu-latest
-    steps:
-      - name: Making sure that they are abvailable now.
-        run: |
-          status=""
-          counter=0
-          while [[ $status != \"built\" ]]
-          do
-              status=$(curl -s \
-              -H "Accept: application/vnd.github.v3+json" \
-              https://api.github.com/repos/kubeshop/helm-charts/pages/builds/latest \
-              --header "Authorization: Bearer $USER_TOKEN" | jq .status)
-              echo "Checking latest GH pages build status --> $status"
-              sleep 5
+  # checking_that_ghpages_updated:
+  #   needs: refreshing_gh_pages
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Making sure that they are abvailable now.
+  #       run: |
+  #         status=""
+  #         counter=0
+  #         while [[ $status != \"built\" ]]
+  #         do
+  #             status=$(curl -s \
+  #             -H "Accept: application/vnd.github.v3+json" \
+  #             https://api.github.com/repos/kubeshop/helm-charts/pages/builds/latest \
+  #             --header "Authorization: Bearer $USER_TOKEN" | jq .status)
+  #             echo "Checking latest GH pages build status --> $status"
+  #             sleep 5
 
-              counter=$(expr $counter + 1)
-              if [[ $status == \"errored\" ]] || [[ $counter == 120 ]]; then
-                echo "Something went wrong. Please check GH's pages issues."
-                exit 1
-              fi
-          done
-        env:
-          # You must create a personal token with repo access as GitHub does
-          # not yet support server-to-server page builds.
-          USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+  #             counter=$(expr $counter + 1)
+  #             if [[ $status == \"errored\" ]] || [[ $counter == 120 ]]; then
+  #               echo "Something went wrong. Please check GH's pages issues."
+  #               exit 1
+  #             fi
+  #         done
+  #       env:
+  #         # You must create a personal token with repo access as GitHub does
+  #         # not yet support server-to-server page builds.
+  #         USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
 
-  notify_slack_if_release_succeeds:
-    runs-on: ubuntu-latest
-    needs: checking_that_ghpages_updated
-    steps:
-      - name: Slack Notification if the helm release pipeline succeeded.
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: testkube-logs
-          SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_TITLE: Helm chart release succeed and GH pages got updated :party_blob:!
-          SLACK_USERNAME: GitHub
-          SLACK_LINK_NAMES: true
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_FOOTER: "Kubeshop --> TestKube"
+  # notify_slack_if_release_succeeds:
+  #   runs-on: ubuntu-latest
+  #   needs: checking_that_ghpages_updated
+  #   steps:
+  #     - name: Slack Notification if the helm release pipeline succeeded.
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_CHANNEL: testkube-logs
+  #         SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
+  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
+  #         SLACK_TITLE: Helm chart release succeed and GH pages got updated :party_blob:!
+  #         SLACK_USERNAME: GitHub
+  #         SLACK_LINK_NAMES: true
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #         SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  notify_slack_if_gh_pages_update_failed:
-    runs-on: ubuntu-latest
-    needs: checking_that_ghpages_updated
-    if: always() && (needs.checking_that_ghpages_updated.result == 'failure')
-    steps:
-      - name: Slack Notification if the helm release GH Pages failed.
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: testkube-logs
-          SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_TITLE: Helm chart release failed on GH pages update! :boom:!
-          SLACK_USERNAME: GitHub
-          SLACK_LINK_NAMES: true
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_FOOTER: "Kubeshop --> TestKube"
+  # notify_slack_if_gh_pages_update_failed:
+  #   runs-on: ubuntu-latest
+  #   needs: checking_that_ghpages_updated
+  #   if: always() && (needs.checking_that_ghpages_updated.result == 'failure')
+  #   steps:
+  #     - name: Slack Notification if the helm release GH Pages failed.
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_CHANNEL: testkube-logs
+  #         SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
+  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
+  #         SLACK_TITLE: Helm chart release failed on GH pages update! :boom:!
+  #         SLACK_USERNAME: GitHub
+  #         SLACK_LINK_NAMES: true
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #         SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  deploy-to-testkube-dev-gke:
-    name: Deploy
-    runs-on: ubuntu-latest
-    needs: notify_slack_if_release_succeeds
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+  # deploy-to-testkube-dev-gke:
+  #   name: Deploy
+  #   runs-on: ubuntu-latest
+  #   needs: notify_slack_if_release_succeeds
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+  #     - name: Configure Git
+  #       run: |
+  #         git config user.name "$GITHUB_ACTOR"
+  #         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      # Setup gcloud CLI
-      - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
-        with:
-          service_account_key: ${{ secrets.GKE_SA_KEY }}
-          project_id: ${{ secrets.GKE_PROJECT }}
+  #     # Setup gcloud CLI
+  #     - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
+  #       with:
+  #         service_account_key: ${{ secrets.GKE_SA_KEY }}
+  #         project_id: ${{ secrets.GKE_PROJECT }}
 
-      # Configure Docker to use the gcloud command-line tool as a credential
-      # helper for authentication
-      - run: |-
-          gcloud --quiet auth configure-docker
+  #     # Configure Docker to use the gcloud command-line tool as a credential
+  #     # helper for authentication
+  #     - run: |-
+  #         gcloud --quiet auth configure-docker
 
-      # Get the GKE credentials so we can deploy to the cluster
-      - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
-        with:
-          cluster_name: ${{ env.GKE_CLUSTER_NAME_DEV }}
-          location: ${{ env.GKE_ZONE_DEV }}
-          credentials: ${{ secrets.GKE_SA_KEY }}
+  #     # Get the GKE credentials so we can deploy to the cluster
+  #     - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
+  #       with:
+  #         cluster_name: ${{ env.GKE_CLUSTER_NAME_DEV }}
+  #         location: ${{ env.GKE_ZONE_DEV }}
+  #         credentials: ${{ secrets.GKE_SA_KEY }}
 
-      - name: Install Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.4.0
+  #     - name: Install Helm
+  #       uses: azure/setup-helm@v1
+  #       with:
+  #         version: v3.4.0
 
-      - name: Installing repositories
-        run: |
-          helm repo add helm-charts https://kubeshop.github.io/helm-charts
-          helm repo add bitnami https://charts.bitnami.com/bitnami
+  #     - name: Installing repositories
+  #       run: |
+  #         helm repo add helm-charts https://kubeshop.github.io/helm-charts
+  #         helm repo add bitnami https://charts.bitnami.com/bitnami
 
-      # Deploy the Docker image to the GKE cluster
-      - name: Deploy
-        run: |-
-          helm upgrade --install --atomic --timeout 180s testkube helm-charts/testkube --namespace testkube --create-namespace --values ./charts/testkube/values-demo.yaml --debug --set testkube-api.cliIngress.oauth.clientID=${{ secrets.TESTKUBE_DEMO_OAUTH_CLIENT_ID }} --set testkube-api.cliIngress.oauth.clientSecret=${{ secrets.TESTKUBE_DEMO_OAUTH_CLIENT_SECRET }}
+  #     # Deploy the Docker image to the GKE cluster
+  #     - name: Deploy
+  #       run: |-
+  #         helm upgrade --install --atomic --timeout 180s testkube helm-charts/testkube --namespace testkube --create-namespace --values ./charts/testkube/values-demo.yaml --debug --set testkube-api.cliIngress.oauth.clientID=${{ secrets.TESTKUBE_DEMO_OAUTH_CLIENT_ID }} --set testkube-api.cliIngress.oauth.clientSecret=${{ secrets.TESTKUBE_DEMO_OAUTH_CLIENT_SECRET }}
 
-  notify_slack_if_deploy_dev_succeeds:
-    runs-on: ubuntu-latest
-    needs: deploy-to-testkube-dev-gke
-    steps:
-      - name: Slack Notification if the helm release deployment to DEV GKS succeeded.
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: testkube-logs
-          SLACK_COLOR: ${{ needs.deploy-to-testkube-dev-gke.result }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_TITLE: Helm chart release successfully deployed into ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE :party_blob:!
-          SLACK_USERNAME: GitHub
-          SLACK_LINK_NAMES: true
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_FOOTER: "Kubeshop --> TestKube"
+  # notify_slack_if_deploy_dev_succeeds:
+  #   runs-on: ubuntu-latest
+  #   needs: deploy-to-testkube-dev-gke
+  #   steps:
+  #     - name: Slack Notification if the helm release deployment to DEV GKS succeeded.
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_CHANNEL: testkube-logs
+  #         SLACK_COLOR: ${{ needs.deploy-to-testkube-dev-gke.result }} # or a specific color like 'good' or '#ff00ff'
+  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
+  #         SLACK_TITLE: Helm chart release successfully deployed into ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE :party_blob:!
+  #         SLACK_USERNAME: GitHub
+  #         SLACK_LINK_NAMES: true
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #         SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  notify_slack_if_deploy_dev_failed:
-    runs-on: ubuntu-latest
-    needs: deploy-to-testkube-dev-gke
-    if: always() && (needs.deploy-to-testkube-dev-gke.result == 'failure')
-    steps:
-      - name: Slack Notification if the helm release deployment to DEV GKS failed.
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: testkube-logs
-          SLACK_COLOR: ${{ needs.deploy-to-testkube-dev-gke.result }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_TITLE: Helm chart release failed to deploy into ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE! :boom:!
-          SLACK_USERNAME: GitHub
-          SLACK_LINK_NAMES: true
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_FOOTER: "Kubeshop --> TestKube"
+  # notify_slack_if_deploy_dev_failed:
+  #   runs-on: ubuntu-latest
+  #   needs: deploy-to-testkube-dev-gke
+  #   if: always() && (needs.deploy-to-testkube-dev-gke.result == 'failure')
+  #   steps:
+  #     - name: Slack Notification if the helm release deployment to DEV GKS failed.
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_CHANNEL: testkube-logs
+  #         SLACK_COLOR: ${{ needs.deploy-to-testkube-dev-gke.result }} # or a specific color like 'good' or '#ff00ff'
+  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
+  #         SLACK_TITLE: Helm chart release failed to deploy into ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE! :boom:!
+  #         SLACK_USERNAME: GitHub
+  #         SLACK_LINK_NAMES: true
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #         SLACK_FOOTER: "Kubeshop --> TestKube"
 
   test_suite_run_dev:
     name: test suite for DEV GKE.
@@ -245,71 +246,79 @@ jobs:
           location: ${{ env.GKE_ZONE_DEV }}
           credentials: ${{ secrets.GKE_SA_KEY }}
 
-      # Prepare test suite
-      - name: Prepare test suite
+      - name: Install testkube kubectl plugin and disable telemetry
+        run: bash < <(curl -sSLf https://kubeshop.github.io/testkube/install.sh ) && kubectl testkube disable telemetry
+
+      - name: Checkout tests from main Testkube repo
+        uses: actions/checkout@v3
+        with:
+          repository: kubeshop/testkube
+          path: testkube-repo
+
+      - name: Executor tests - delete/create/schedule all executor tests
+        working-directory: ./testkube-repo
+        run: chmod +x ./test/scripts/executor-tests/run.sh && ./test/scripts/executor-tests/run.sh -c -s # (create/update, schedule) - don't execute
+
+      - name: (Re)create Postman Sanity test (with CLI)
+        working-directory: ./testkube-repo
         run: |-
-          # Downloading test suite:
-          curl -LOs https://raw.githubusercontent.com/kubeshop/testkube/main/${{ env.POSTMAN_TEST_FILE_PATH }}/${{ env.POSTMAN_TEST_FILE_NANE }}
+          # enabling debug mode
+          set -x
+          kubectl -n testkube delete test sanity --ignore-not-found=true
+          kubectl -n testkube delete secret sanity-secrets --ignore-not-found=true
+          kubectl testkube create test -f ./test/postman/TestKube-Sanity.postman_collection.json --name sanity --type postman/collection -v api_uri=http://testkube-api-server:8088 -v test_api_uri=http://testkube-api-server:8088 -v test_type=postman/collection -v test_name=fill-me -v execution_name=fill-me
+          
+      - name: Run Postman sanity tests
+        run: kubectl testkube run test sanity -f
 
-          # Clean Test suite:
-          kubectl -n testkube delete test sanity || true
-          kubectl -n testkube delete secret sanity-secrets || true
+      - name: (Re)create Dashboard E2E tests (from CRD)
+        working-directory: ./testkube-repo
+        run: |-
+          # enabling debug mode
+          set -x
+          kubectl -n testkube delete test dashboard-e2e-tests --ignore-not-found=true
+          kubectl apply -f ./test/dashboard-e2e/crd/crd.yaml
 
-      # Disabling telemetry
-      - name: Disable telemetry
-        id: disable_telemetry
-        uses: kubeshop/testkube-docker-action@v1
-        with:
-          command: disable
-          resource: telemetry
+      - name: (Re)create demo testsuite
+        working-directory: ./testkube-repo
+        run: |-
+          # enabling debug mode
+          set -x
+          kubectl -n testkube delete testsuite demo-testsuite --ignore-not-found=true
+          kubectl testkube create testsuite -f ./test/suites/demo-testsuite.json --name demo-testsuite
 
-      # Creating test suite
-      - name: Create test_testsuite
-        id: create_test_suite
-        uses: kubeshop/testkube-docker-action@v1
-        with:
-          command: create
-          resource: test
-          parameters: "-f ./${{ env.POSTMAN_TEST_FILE_NANE }} --name sanity --type postman/collection  -v api_uri=http://testkube-api-server:8088 -v test_api_uri=http://testkube-api-server:8088 -v test_type=postman/collection -v test_name=fill-me -v execution_name=fill-me"
+      - name: Run demo testsuite
+        run: kubectl testkube run testsuite demo-testsuite -f
 
-      # Running test suite
-      - name: Run test suite
-        id: run_test_suite
-        uses: kubeshop/testkube-docker-action@v1
-        with:
-          command: run
-          resource: test
-          parameters: "sanity -f"
+  # notify_slack_if_test_suite_dev_succeeds:
+  #   runs-on: ubuntu-latest
+  #   needs: test_suite_run_dev
+  #   steps:
+  #     - name: Slack Notification if the test suite run on DEV GKS succeeded.
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_CHANNEL: testkube-logs
+  #         SLACK_COLOR: ${{ needs.test_suite_run_dev.result }} # or a specific color like 'good' or '#ff00ff'
+  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
+  #         SLACK_TITLE: Test suite successfully run against ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE :party_blob:!
+  #         SLACK_USERNAME: GitHub
+  #         SLACK_LINK_NAMES: true
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #         SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  notify_slack_if_test_suite_dev_succeeds:
-    runs-on: ubuntu-latest
-    needs: test_suite_run_dev
-    steps:
-      - name: Slack Notification if the test suite run on DEV GKS succeeded.
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: testkube-logs
-          SLACK_COLOR: ${{ needs.test_suite_run_dev.result }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_TITLE: Test suite successfully run against ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE :party_blob:!
-          SLACK_USERNAME: GitHub
-          SLACK_LINK_NAMES: true
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_FOOTER: "Kubeshop --> TestKube"
-
-  notify_slack_if_test_suite_failed:
-    runs-on: ubuntu-latest
-    needs: test_suite_run_dev
-    if: always() && (needs.test_suite_run_dev.result == 'failure')
-    steps:
-      - name: Slack Notification if the test suite run on DEV GKS failed.
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: testkube-logs
-          SLACK_COLOR: ${{ needs.test_suite_run_dev.result }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_TITLE: Test suite FAILED to run on ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE! :boom:!
-          SLACK_USERNAME: GitHub
-          SLACK_LINK_NAMES: true
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_FOOTER: "Kubeshop --> TestKube"
+  # notify_slack_if_test_suite_failed:
+  #   runs-on: ubuntu-latest
+  #   needs: test_suite_run_dev
+  #   if: always() && (needs.test_suite_run_dev.result == 'failure')
+  #   steps:
+  #     - name: Slack Notification if the test suite run on DEV GKS failed.
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_CHANNEL: testkube-logs
+  #         SLACK_COLOR: ${{ needs.test_suite_run_dev.result }} # or a specific color like 'good' or '#ff00ff'
+  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
+  #         SLACK_TITLE: Test suite FAILED to run on ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE! :boom:!
+  #         SLACK_USERNAME: GitHub
+  #         SLACK_LINK_NAMES: true
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #         SLACK_FOOTER: "Kubeshop --> TestKube"

--- a/.github/workflows/helm-releaser-testkube-charts.yaml
+++ b/.github/workflows/helm-releaser-testkube-charts.yaml
@@ -277,11 +277,10 @@ jobs:
       - name: Create Postman Sanity test (action)
         id: create_postman_sanity_test
         uses: kubeshop/testkube-docker-action@v1
-        working-directory: ./testkube-repo
         with:
           command: create
           resource: test
-          parameters: "-f ./test/postman/TestKube-Sanity.postman_collection.json --name sanity --type postman/collection  -v api_uri=http://testkube-api-server:8088 -v test_api_uri=http://testkube-api-server:8088 -v test_type=postman/collection -v test_name=fill-me -v execution_name=fill-me"
+          parameters: "-f ./testkube-repo/test/postman/TestKube-Sanity.postman_collection.json --name sanity --type postman/collection  -v api_uri=http://testkube-api-server:8088 -v test_api_uri=http://testkube-api-server:8088 -v test_type=postman/collection -v test_name=fill-me -v execution_name=fill-me"
 
       - name: Run Postman Sanity test (action)
         id: run_postman_sanity_test

--- a/.github/workflows/helm-releaser-testkube-charts.yaml
+++ b/.github/workflows/helm-releaser-testkube-charts.yaml
@@ -226,7 +226,7 @@ jobs:
   test_suite_run_dev:
     name: test suite for DEV GKE.
     runs-on: ubuntu-latest
-    needs: deploy-to-testkube-dev-gke
+    # needs: deploy-to-testkube-dev-gke
     steps:
       # Setup gcloud CLI
       - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7

--- a/.github/workflows/helm-releaser-testkube-charts.yaml
+++ b/.github/workflows/helm-releaser-testkube-charts.yaml
@@ -1,15 +1,12 @@
 name: Releasing Helm charts.
 
-# on:
-#   push:
-#     paths:
-#       - "charts/testkube**"
-#       - "charts/testkube-api/**"
-#     branches:
-#       - main
-
 on:
-  pull_request:
+  push:
+    paths:
+      - "charts/testkube**"
+      - "charts/testkube-api/**"
+    branches:
+      - main
 
 env:
   PROJECT_ID: ${{ secrets.GKE_PROJECT }}
@@ -18,215 +15,215 @@ env:
   DEPLOYMENT_NAME: testkube # Add your deployment name here.
 
 jobs:
-  # release_charts:
-  #   runs-on: ubuntu-latest
+  release_charts:
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-  #     - name: Configure Git
-  #       run: |
-  #         git config user.name "$GITHUB_ACTOR"
-  #         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-  #     - name: Install Helm
-  #       uses: azure/setup-helm@v1
-  #       with:
-  #         version: v3.4.0
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
 
-  #     - name: Installing repositories
-  #       run: |
-  #         helm repo add helm-charts https://kubeshop.github.io/helm-charts
-  #         helm repo add bitnami https://charts.bitnami.com/bitnami
+      - name: Installing repositories
+        run: |
+          helm repo add helm-charts https://kubeshop.github.io/helm-charts
+          helm repo add bitnami https://charts.bitnami.com/bitnami
 
-  #     - name: Run chart-releaser
-  #       uses: helm/chart-releaser-action@v1.2.1
-  #       with:
-  #         charts_dir: charts
-  #       env:
-  #         CR_TOKEN: "${{ secrets.CI_BOT_TOKEN }}"
-  #         CR_SKIP_EXISTING: true
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.2.1
+        with:
+          charts_dir: charts
+        env:
+          CR_TOKEN: "${{ secrets.CI_BOT_TOKEN }}"
+          CR_SKIP_EXISTING: true
 
-  # notify_slack_if_helm_chart_release_fails:
-  #   runs-on: ubuntu-latest
-  #   needs: release_charts
-  #   if: always() && (needs.release_charts.result == 'failure')
-  #   steps:
-  #     - name: Slack Notification if Helm Release action failed
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: testkube-logs
-  #         SLACK_COLOR: ${{ needs.release_charts.result }} # or a specific color like 'good' or '#ff00ff'
-  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
-  #         SLACK_TITLE: Helm Chart release action failed :boom:!
-  #         SLACK_USERNAME: GitHub
-  #         SLACK_LINK_NAMES: true
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #         SLACK_FOOTER: "Kubeshop --> TestKube"
+  notify_slack_if_helm_chart_release_fails:
+    runs-on: ubuntu-latest
+    needs: release_charts
+    if: always() && (needs.release_charts.result == 'failure')
+    steps:
+      - name: Slack Notification if Helm Release action failed
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.release_charts.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Helm Chart release action failed :boom:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  # refreshing_gh_pages:
-  #   needs: release_charts
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Triggering refresh for GH-pages to make just released charts available
-  #       run: |
-  #         curl -s --fail --request POST \
-  #           --url https://api.github.com/repos/kubeshop/helm-charts/pages/builds \
-  #           --header "Authorization: Bearer $USER_TOKEN"
-  #       env:
-  #         # You must create a personal token with repo access as GitHub does
-  #         # not yet support server-to-server page builds.
-  #         USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+  refreshing_gh_pages:
+    needs: release_charts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Triggering refresh for GH-pages to make just released charts available
+        run: |
+          curl -s --fail --request POST \
+            --url https://api.github.com/repos/kubeshop/helm-charts/pages/builds \
+            --header "Authorization: Bearer $USER_TOKEN"
+        env:
+          # You must create a personal token with repo access as GitHub does
+          # not yet support server-to-server page builds.
+          USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
 
-  # checking_that_ghpages_updated:
-  #   needs: refreshing_gh_pages
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Making sure that they are abvailable now.
-  #       run: |
-  #         status=""
-  #         counter=0
-  #         while [[ $status != \"built\" ]]
-  #         do
-  #             status=$(curl -s \
-  #             -H "Accept: application/vnd.github.v3+json" \
-  #             https://api.github.com/repos/kubeshop/helm-charts/pages/builds/latest \
-  #             --header "Authorization: Bearer $USER_TOKEN" | jq .status)
-  #             echo "Checking latest GH pages build status --> $status"
-  #             sleep 5
+  checking_that_ghpages_updated:
+    needs: refreshing_gh_pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Making sure that they are abvailable now.
+        run: |
+          status=""
+          counter=0
+          while [[ $status != \"built\" ]]
+          do
+              status=$(curl -s \
+              -H "Accept: application/vnd.github.v3+json" \
+              https://api.github.com/repos/kubeshop/helm-charts/pages/builds/latest \
+              --header "Authorization: Bearer $USER_TOKEN" | jq .status)
+              echo "Checking latest GH pages build status --> $status"
+              sleep 5
 
-  #             counter=$(expr $counter + 1)
-  #             if [[ $status == \"errored\" ]] || [[ $counter == 120 ]]; then
-  #               echo "Something went wrong. Please check GH's pages issues."
-  #               exit 1
-  #             fi
-  #         done
-  #       env:
-  #         # You must create a personal token with repo access as GitHub does
-  #         # not yet support server-to-server page builds.
-  #         USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+              counter=$(expr $counter + 1)
+              if [[ $status == \"errored\" ]] || [[ $counter == 120 ]]; then
+                echo "Something went wrong. Please check GH's pages issues."
+                exit 1
+              fi
+          done
+        env:
+          # You must create a personal token with repo access as GitHub does
+          # not yet support server-to-server page builds.
+          USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
 
-  # notify_slack_if_release_succeeds:
-  #   runs-on: ubuntu-latest
-  #   needs: checking_that_ghpages_updated
-  #   steps:
-  #     - name: Slack Notification if the helm release pipeline succeeded.
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: testkube-logs
-  #         SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
-  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
-  #         SLACK_TITLE: Helm chart release succeed and GH pages got updated :party_blob:!
-  #         SLACK_USERNAME: GitHub
-  #         SLACK_LINK_NAMES: true
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #         SLACK_FOOTER: "Kubeshop --> TestKube"
+  notify_slack_if_release_succeeds:
+    runs-on: ubuntu-latest
+    needs: checking_that_ghpages_updated
+    steps:
+      - name: Slack Notification if the helm release pipeline succeeded.
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Helm chart release succeed and GH pages got updated :party_blob:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  # notify_slack_if_gh_pages_update_failed:
-  #   runs-on: ubuntu-latest
-  #   needs: checking_that_ghpages_updated
-  #   if: always() && (needs.checking_that_ghpages_updated.result == 'failure')
-  #   steps:
-  #     - name: Slack Notification if the helm release GH Pages failed.
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: testkube-logs
-  #         SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
-  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
-  #         SLACK_TITLE: Helm chart release failed on GH pages update! :boom:!
-  #         SLACK_USERNAME: GitHub
-  #         SLACK_LINK_NAMES: true
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #         SLACK_FOOTER: "Kubeshop --> TestKube"
+  notify_slack_if_gh_pages_update_failed:
+    runs-on: ubuntu-latest
+    needs: checking_that_ghpages_updated
+    if: always() && (needs.checking_that_ghpages_updated.result == 'failure')
+    steps:
+      - name: Slack Notification if the helm release GH Pages failed.
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Helm chart release failed on GH pages update! :boom:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  # deploy-to-testkube-dev-gke:
-  #   name: Deploy
-  #   runs-on: ubuntu-latest
-  #   needs: notify_slack_if_release_succeeds
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
+  deploy-to-testkube-dev-gke:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: notify_slack_if_release_succeeds
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-  #     - name: Configure Git
-  #       run: |
-  #         git config user.name "$GITHUB_ACTOR"
-  #         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-  #     # Setup gcloud CLI
-  #     - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
-  #       with:
-  #         service_account_key: ${{ secrets.GKE_SA_KEY }}
-  #         project_id: ${{ secrets.GKE_PROJECT }}
+      # Setup gcloud CLI
+      - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
+        with:
+          service_account_key: ${{ secrets.GKE_SA_KEY }}
+          project_id: ${{ secrets.GKE_PROJECT }}
 
-  #     # Configure Docker to use the gcloud command-line tool as a credential
-  #     # helper for authentication
-  #     - run: |-
-  #         gcloud --quiet auth configure-docker
+      # Configure Docker to use the gcloud command-line tool as a credential
+      # helper for authentication
+      - run: |-
+          gcloud --quiet auth configure-docker
 
-  #     # Get the GKE credentials so we can deploy to the cluster
-  #     - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
-  #       with:
-  #         cluster_name: ${{ env.GKE_CLUSTER_NAME_DEV }}
-  #         location: ${{ env.GKE_ZONE_DEV }}
-  #         credentials: ${{ secrets.GKE_SA_KEY }}
+      # Get the GKE credentials so we can deploy to the cluster
+      - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
+        with:
+          cluster_name: ${{ env.GKE_CLUSTER_NAME_DEV }}
+          location: ${{ env.GKE_ZONE_DEV }}
+          credentials: ${{ secrets.GKE_SA_KEY }}
 
-  #     - name: Install Helm
-  #       uses: azure/setup-helm@v1
-  #       with:
-  #         version: v3.4.0
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
 
-  #     - name: Installing repositories
-  #       run: |
-  #         helm repo add helm-charts https://kubeshop.github.io/helm-charts
-  #         helm repo add bitnami https://charts.bitnami.com/bitnami
+      - name: Installing repositories
+        run: |
+          helm repo add helm-charts https://kubeshop.github.io/helm-charts
+          helm repo add bitnami https://charts.bitnami.com/bitnami
 
-  #     # Deploy the Docker image to the GKE cluster
-  #     - name: Deploy
-  #       run: |-
-  #         helm upgrade --install --atomic --timeout 180s testkube helm-charts/testkube --namespace testkube --create-namespace --values ./charts/testkube/values-demo.yaml --debug --set testkube-api.cliIngress.oauth.clientID=${{ secrets.TESTKUBE_DEMO_OAUTH_CLIENT_ID }} --set testkube-api.cliIngress.oauth.clientSecret=${{ secrets.TESTKUBE_DEMO_OAUTH_CLIENT_SECRET }}
+      # Deploy the Docker image to the GKE cluster
+      - name: Deploy
+        run: |-
+          helm upgrade --install --atomic --timeout 180s testkube helm-charts/testkube --namespace testkube --create-namespace --values ./charts/testkube/values-demo.yaml --debug --set testkube-api.cliIngress.oauth.clientID=${{ secrets.TESTKUBE_DEMO_OAUTH_CLIENT_ID }} --set testkube-api.cliIngress.oauth.clientSecret=${{ secrets.TESTKUBE_DEMO_OAUTH_CLIENT_SECRET }}
 
-  # notify_slack_if_deploy_dev_succeeds:
-  #   runs-on: ubuntu-latest
-  #   needs: deploy-to-testkube-dev-gke
-  #   steps:
-  #     - name: Slack Notification if the helm release deployment to DEV GKS succeeded.
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: testkube-logs
-  #         SLACK_COLOR: ${{ needs.deploy-to-testkube-dev-gke.result }} # or a specific color like 'good' or '#ff00ff'
-  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
-  #         SLACK_TITLE: Helm chart release successfully deployed into ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE :party_blob:!
-  #         SLACK_USERNAME: GitHub
-  #         SLACK_LINK_NAMES: true
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #         SLACK_FOOTER: "Kubeshop --> TestKube"
+  notify_slack_if_deploy_dev_succeeds:
+    runs-on: ubuntu-latest
+    needs: deploy-to-testkube-dev-gke
+    steps:
+      - name: Slack Notification if the helm release deployment to DEV GKS succeeded.
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.deploy-to-testkube-dev-gke.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Helm chart release successfully deployed into ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE :party_blob:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  # notify_slack_if_deploy_dev_failed:
-  #   runs-on: ubuntu-latest
-  #   needs: deploy-to-testkube-dev-gke
-  #   if: always() && (needs.deploy-to-testkube-dev-gke.result == 'failure')
-  #   steps:
-  #     - name: Slack Notification if the helm release deployment to DEV GKS failed.
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: testkube-logs
-  #         SLACK_COLOR: ${{ needs.deploy-to-testkube-dev-gke.result }} # or a specific color like 'good' or '#ff00ff'
-  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
-  #         SLACK_TITLE: Helm chart release failed to deploy into ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE! :boom:!
-  #         SLACK_USERNAME: GitHub
-  #         SLACK_LINK_NAMES: true
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #         SLACK_FOOTER: "Kubeshop --> TestKube"
+  notify_slack_if_deploy_dev_failed:
+    runs-on: ubuntu-latest
+    needs: deploy-to-testkube-dev-gke
+    if: always() && (needs.deploy-to-testkube-dev-gke.result == 'failure')
+    steps:
+      - name: Slack Notification if the helm release deployment to DEV GKS failed.
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.deploy-to-testkube-dev-gke.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Helm chart release failed to deploy into ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE! :boom:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"
 
   test_suite_run_dev:
     name: test suite for DEV GKE.
     runs-on: ubuntu-latest
-    # needs: deploy-to-testkube-dev-gke
+    needs: deploy-to-testkube-dev-gke
     steps:
       # Setup gcloud CLI
       - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
@@ -308,35 +305,35 @@ jobs:
       - name: Run demo testsuite (CLI)
         run: kubectl testkube run testsuite demo-testsuite -f
 
-  # notify_slack_if_test_suite_dev_succeeds:
-  #   runs-on: ubuntu-latest
-  #   needs: test_suite_run_dev
-  #   steps:
-  #     - name: Slack Notification if the test suite run on DEV GKS succeeded.
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: testkube-logs
-  #         SLACK_COLOR: ${{ needs.test_suite_run_dev.result }} # or a specific color like 'good' or '#ff00ff'
-  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
-  #         SLACK_TITLE: Test suite successfully run against ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE :party_blob:!
-  #         SLACK_USERNAME: GitHub
-  #         SLACK_LINK_NAMES: true
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #         SLACK_FOOTER: "Kubeshop --> TestKube"
+  notify_slack_if_test_suite_dev_succeeds:
+    runs-on: ubuntu-latest
+    needs: test_suite_run_dev
+    steps:
+      - name: Slack Notification if the test suite run on DEV GKS succeeded.
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.test_suite_run_dev.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Test suite successfully run against ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE :party_blob:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  # notify_slack_if_test_suite_failed:
-  #   runs-on: ubuntu-latest
-  #   needs: test_suite_run_dev
-  #   if: always() && (needs.test_suite_run_dev.result == 'failure')
-  #   steps:
-  #     - name: Slack Notification if the test suite run on DEV GKS failed.
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: testkube-logs
-  #         SLACK_COLOR: ${{ needs.test_suite_run_dev.result }} # or a specific color like 'good' or '#ff00ff'
-  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
-  #         SLACK_TITLE: Test suite FAILED to run on ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE! :boom:!
-  #         SLACK_USERNAME: GitHub
-  #         SLACK_LINK_NAMES: true
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #         SLACK_FOOTER: "Kubeshop --> TestKube"
+  notify_slack_if_test_suite_failed:
+    runs-on: ubuntu-latest
+    needs: test_suite_run_dev
+    if: always() && (needs.test_suite_run_dev.result == 'failure')
+    steps:
+      - name: Slack Notification if the test suite run on DEV GKS failed.
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.test_suite_run_dev.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Test suite FAILED to run on ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE! :boom:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"

--- a/.github/workflows/helm-releaser-testkube-charts.yaml
+++ b/.github/workflows/helm-releaser-testkube-charts.yaml
@@ -1,12 +1,15 @@
 name: Releasing Helm charts.
 
+# on:
+#   push:
+#     paths:
+#       - "charts/testkube**"
+#       - "charts/testkube-api/**"
+#     branches:
+#       - main
+
 on:
-  push:
-    paths:
-      - "charts/testkube**"
-      - "charts/testkube-api/**"
-    branches:
-      - main
+  pull_request:
 
 env:
   PROJECT_ID: ${{ secrets.GKE_PROJECT }}
@@ -15,215 +18,215 @@ env:
   DEPLOYMENT_NAME: testkube # Add your deployment name here.
 
 jobs:
-  release_charts:
-    runs-on: ubuntu-latest
+  # release_charts:
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+  #     - name: Configure Git
+  #       run: |
+  #         git config user.name "$GITHUB_ACTOR"
+  #         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Install Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.4.0
+  #     - name: Install Helm
+  #       uses: azure/setup-helm@v1
+  #       with:
+  #         version: v3.4.0
 
-      - name: Installing repositories
-        run: |
-          helm repo add helm-charts https://kubeshop.github.io/helm-charts
-          helm repo add bitnami https://charts.bitnami.com/bitnami
+  #     - name: Installing repositories
+  #       run: |
+  #         helm repo add helm-charts https://kubeshop.github.io/helm-charts
+  #         helm repo add bitnami https://charts.bitnami.com/bitnami
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
-        with:
-          charts_dir: charts
-        env:
-          CR_TOKEN: "${{ secrets.CI_BOT_TOKEN }}"
-          CR_SKIP_EXISTING: true
+  #     - name: Run chart-releaser
+  #       uses: helm/chart-releaser-action@v1.2.1
+  #       with:
+  #         charts_dir: charts
+  #       env:
+  #         CR_TOKEN: "${{ secrets.CI_BOT_TOKEN }}"
+  #         CR_SKIP_EXISTING: true
 
-  notify_slack_if_helm_chart_release_fails:
-    runs-on: ubuntu-latest
-    needs: release_charts
-    if: always() && (needs.release_charts.result == 'failure')
-    steps:
-      - name: Slack Notification if Helm Release action failed
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: testkube-logs
-          SLACK_COLOR: ${{ needs.release_charts.result }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_TITLE: Helm Chart release action failed :boom:!
-          SLACK_USERNAME: GitHub
-          SLACK_LINK_NAMES: true
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_FOOTER: "Kubeshop --> TestKube"
+  # notify_slack_if_helm_chart_release_fails:
+  #   runs-on: ubuntu-latest
+  #   needs: release_charts
+  #   if: always() && (needs.release_charts.result == 'failure')
+  #   steps:
+  #     - name: Slack Notification if Helm Release action failed
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_CHANNEL: testkube-logs
+  #         SLACK_COLOR: ${{ needs.release_charts.result }} # or a specific color like 'good' or '#ff00ff'
+  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
+  #         SLACK_TITLE: Helm Chart release action failed :boom:!
+  #         SLACK_USERNAME: GitHub
+  #         SLACK_LINK_NAMES: true
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #         SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  refreshing_gh_pages:
-    needs: release_charts
-    runs-on: ubuntu-latest
-    steps:
-      - name: Triggering refresh for GH-pages to make just released charts available
-        run: |
-          curl -s --fail --request POST \
-            --url https://api.github.com/repos/kubeshop/helm-charts/pages/builds \
-            --header "Authorization: Bearer $USER_TOKEN"
-        env:
-          # You must create a personal token with repo access as GitHub does
-          # not yet support server-to-server page builds.
-          USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+  # refreshing_gh_pages:
+  #   needs: release_charts
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Triggering refresh for GH-pages to make just released charts available
+  #       run: |
+  #         curl -s --fail --request POST \
+  #           --url https://api.github.com/repos/kubeshop/helm-charts/pages/builds \
+  #           --header "Authorization: Bearer $USER_TOKEN"
+  #       env:
+  #         # You must create a personal token with repo access as GitHub does
+  #         # not yet support server-to-server page builds.
+  #         USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
 
-  checking_that_ghpages_updated:
-    needs: refreshing_gh_pages
-    runs-on: ubuntu-latest
-    steps:
-      - name: Making sure that they are abvailable now.
-        run: |
-          status=""
-          counter=0
-          while [[ $status != \"built\" ]]
-          do
-              status=$(curl -s \
-              -H "Accept: application/vnd.github.v3+json" \
-              https://api.github.com/repos/kubeshop/helm-charts/pages/builds/latest \
-              --header "Authorization: Bearer $USER_TOKEN" | jq .status)
-              echo "Checking latest GH pages build status --> $status"
-              sleep 5
+  # checking_that_ghpages_updated:
+  #   needs: refreshing_gh_pages
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Making sure that they are abvailable now.
+  #       run: |
+  #         status=""
+  #         counter=0
+  #         while [[ $status != \"built\" ]]
+  #         do
+  #             status=$(curl -s \
+  #             -H "Accept: application/vnd.github.v3+json" \
+  #             https://api.github.com/repos/kubeshop/helm-charts/pages/builds/latest \
+  #             --header "Authorization: Bearer $USER_TOKEN" | jq .status)
+  #             echo "Checking latest GH pages build status --> $status"
+  #             sleep 5
 
-              counter=$(expr $counter + 1)
-              if [[ $status == \"errored\" ]] || [[ $counter == 120 ]]; then
-                echo "Something went wrong. Please check GH's pages issues."
-                exit 1
-              fi
-          done
-        env:
-          # You must create a personal token with repo access as GitHub does
-          # not yet support server-to-server page builds.
-          USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+  #             counter=$(expr $counter + 1)
+  #             if [[ $status == \"errored\" ]] || [[ $counter == 120 ]]; then
+  #               echo "Something went wrong. Please check GH's pages issues."
+  #               exit 1
+  #             fi
+  #         done
+  #       env:
+  #         # You must create a personal token with repo access as GitHub does
+  #         # not yet support server-to-server page builds.
+  #         USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
 
-  notify_slack_if_release_succeeds:
-    runs-on: ubuntu-latest
-    needs: checking_that_ghpages_updated
-    steps:
-      - name: Slack Notification if the helm release pipeline succeeded.
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: testkube-logs
-          SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_TITLE: Helm chart release succeed and GH pages got updated :party_blob:!
-          SLACK_USERNAME: GitHub
-          SLACK_LINK_NAMES: true
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_FOOTER: "Kubeshop --> TestKube"
+  # notify_slack_if_release_succeeds:
+  #   runs-on: ubuntu-latest
+  #   needs: checking_that_ghpages_updated
+  #   steps:
+  #     - name: Slack Notification if the helm release pipeline succeeded.
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_CHANNEL: testkube-logs
+  #         SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
+  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
+  #         SLACK_TITLE: Helm chart release succeed and GH pages got updated :party_blob:!
+  #         SLACK_USERNAME: GitHub
+  #         SLACK_LINK_NAMES: true
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #         SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  notify_slack_if_gh_pages_update_failed:
-    runs-on: ubuntu-latest
-    needs: checking_that_ghpages_updated
-    if: always() && (needs.checking_that_ghpages_updated.result == 'failure')
-    steps:
-      - name: Slack Notification if the helm release GH Pages failed.
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: testkube-logs
-          SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_TITLE: Helm chart release failed on GH pages update! :boom:!
-          SLACK_USERNAME: GitHub
-          SLACK_LINK_NAMES: true
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_FOOTER: "Kubeshop --> TestKube"
+  # notify_slack_if_gh_pages_update_failed:
+  #   runs-on: ubuntu-latest
+  #   needs: checking_that_ghpages_updated
+  #   if: always() && (needs.checking_that_ghpages_updated.result == 'failure')
+  #   steps:
+  #     - name: Slack Notification if the helm release GH Pages failed.
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_CHANNEL: testkube-logs
+  #         SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
+  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
+  #         SLACK_TITLE: Helm chart release failed on GH pages update! :boom:!
+  #         SLACK_USERNAME: GitHub
+  #         SLACK_LINK_NAMES: true
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #         SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  deploy-to-testkube-dev-gke:
-    name: Deploy
-    runs-on: ubuntu-latest
-    needs: notify_slack_if_release_succeeds
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+  # deploy-to-testkube-dev-gke:
+  #   name: Deploy
+  #   runs-on: ubuntu-latest
+  #   needs: notify_slack_if_release_succeeds
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+  #     - name: Configure Git
+  #       run: |
+  #         git config user.name "$GITHUB_ACTOR"
+  #         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      # Setup gcloud CLI
-      - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
-        with:
-          service_account_key: ${{ secrets.GKE_SA_KEY }}
-          project_id: ${{ secrets.GKE_PROJECT }}
+  #     # Setup gcloud CLI
+  #     - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
+  #       with:
+  #         service_account_key: ${{ secrets.GKE_SA_KEY }}
+  #         project_id: ${{ secrets.GKE_PROJECT }}
 
-      # Configure Docker to use the gcloud command-line tool as a credential
-      # helper for authentication
-      - run: |-
-          gcloud --quiet auth configure-docker
+  #     # Configure Docker to use the gcloud command-line tool as a credential
+  #     # helper for authentication
+  #     - run: |-
+  #         gcloud --quiet auth configure-docker
 
-      # Get the GKE credentials so we can deploy to the cluster
-      - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
-        with:
-          cluster_name: ${{ env.GKE_CLUSTER_NAME_DEV }}
-          location: ${{ env.GKE_ZONE_DEV }}
-          credentials: ${{ secrets.GKE_SA_KEY }}
+  #     # Get the GKE credentials so we can deploy to the cluster
+  #     - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
+  #       with:
+  #         cluster_name: ${{ env.GKE_CLUSTER_NAME_DEV }}
+  #         location: ${{ env.GKE_ZONE_DEV }}
+  #         credentials: ${{ secrets.GKE_SA_KEY }}
 
-      - name: Install Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.4.0
+  #     - name: Install Helm
+  #       uses: azure/setup-helm@v1
+  #       with:
+  #         version: v3.4.0
 
-      - name: Installing repositories
-        run: |
-          helm repo add helm-charts https://kubeshop.github.io/helm-charts
-          helm repo add bitnami https://charts.bitnami.com/bitnami
+  #     - name: Installing repositories
+  #       run: |
+  #         helm repo add helm-charts https://kubeshop.github.io/helm-charts
+  #         helm repo add bitnami https://charts.bitnami.com/bitnami
 
-      # Deploy the Docker image to the GKE cluster
-      - name: Deploy
-        run: |-
-          helm upgrade --install --atomic --timeout 180s testkube helm-charts/testkube --namespace testkube --create-namespace --values ./charts/testkube/values-demo.yaml --debug --set testkube-api.cliIngress.oauth.clientID=${{ secrets.TESTKUBE_DEMO_OAUTH_CLIENT_ID }} --set testkube-api.cliIngress.oauth.clientSecret=${{ secrets.TESTKUBE_DEMO_OAUTH_CLIENT_SECRET }}
+  #     # Deploy the Docker image to the GKE cluster
+  #     - name: Deploy
+  #       run: |-
+  #         helm upgrade --install --atomic --timeout 180s testkube helm-charts/testkube --namespace testkube --create-namespace --values ./charts/testkube/values-demo.yaml --debug --set testkube-api.cliIngress.oauth.clientID=${{ secrets.TESTKUBE_DEMO_OAUTH_CLIENT_ID }} --set testkube-api.cliIngress.oauth.clientSecret=${{ secrets.TESTKUBE_DEMO_OAUTH_CLIENT_SECRET }}
 
-  notify_slack_if_deploy_dev_succeeds:
-    runs-on: ubuntu-latest
-    needs: deploy-to-testkube-dev-gke
-    steps:
-      - name: Slack Notification if the helm release deployment to DEV GKS succeeded.
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: testkube-logs
-          SLACK_COLOR: ${{ needs.deploy-to-testkube-dev-gke.result }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_TITLE: Helm chart release successfully deployed into ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE :party_blob:!
-          SLACK_USERNAME: GitHub
-          SLACK_LINK_NAMES: true
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_FOOTER: "Kubeshop --> TestKube"
+  # notify_slack_if_deploy_dev_succeeds:
+  #   runs-on: ubuntu-latest
+  #   needs: deploy-to-testkube-dev-gke
+  #   steps:
+  #     - name: Slack Notification if the helm release deployment to DEV GKS succeeded.
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_CHANNEL: testkube-logs
+  #         SLACK_COLOR: ${{ needs.deploy-to-testkube-dev-gke.result }} # or a specific color like 'good' or '#ff00ff'
+  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
+  #         SLACK_TITLE: Helm chart release successfully deployed into ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE :party_blob:!
+  #         SLACK_USERNAME: GitHub
+  #         SLACK_LINK_NAMES: true
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #         SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  notify_slack_if_deploy_dev_failed:
-    runs-on: ubuntu-latest
-    needs: deploy-to-testkube-dev-gke
-    if: always() && (needs.deploy-to-testkube-dev-gke.result == 'failure')
-    steps:
-      - name: Slack Notification if the helm release deployment to DEV GKS failed.
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: testkube-logs
-          SLACK_COLOR: ${{ needs.deploy-to-testkube-dev-gke.result }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_TITLE: Helm chart release failed to deploy into ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE! :boom:!
-          SLACK_USERNAME: GitHub
-          SLACK_LINK_NAMES: true
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_FOOTER: "Kubeshop --> TestKube"
+  # notify_slack_if_deploy_dev_failed:
+  #   runs-on: ubuntu-latest
+  #   needs: deploy-to-testkube-dev-gke
+  #   if: always() && (needs.deploy-to-testkube-dev-gke.result == 'failure')
+  #   steps:
+  #     - name: Slack Notification if the helm release deployment to DEV GKS failed.
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_CHANNEL: testkube-logs
+  #         SLACK_COLOR: ${{ needs.deploy-to-testkube-dev-gke.result }} # or a specific color like 'good' or '#ff00ff'
+  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
+  #         SLACK_TITLE: Helm chart release failed to deploy into ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE! :boom:!
+  #         SLACK_USERNAME: GitHub
+  #         SLACK_LINK_NAMES: true
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #         SLACK_FOOTER: "Kubeshop --> TestKube"
 
   test_suite_run_dev:
     name: test suite for DEV GKE.
     runs-on: ubuntu-latest
-    needs: deploy-to-testkube-dev-gke
+    # needs: deploy-to-testkube-dev-gke
     steps:
       # Setup gcloud CLI
       - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
@@ -243,8 +246,15 @@ jobs:
           location: ${{ env.GKE_ZONE_DEV }}
           credentials: ${{ secrets.GKE_SA_KEY }}
 
-      - name: Install testkube kubectl plugin and disable telemetry
-        run: bash < <(curl -sSLf https://kubeshop.github.io/testkube/install.sh ) && kubectl testkube disable telemetry
+      - name: Install testkube kubectl plugin
+        run: bash < <(curl -sSLf https://kubeshop.github.io/testkube/install.sh )
+
+      - name: Disable telemetry (action)
+        id: disable_telemetry
+        uses: kubeshop/testkube-docker-action@v1
+        with:
+          command: disable
+          resource: telemetry
 
       - name: Checkout tests from main Testkube repo
         uses: actions/checkout@v3
@@ -252,28 +262,39 @@ jobs:
           repository: kubeshop/testkube
           path: testkube-repo
 
-      - name: Executor tests - delete/create/schedule all executor tests
+      - name: Executor tests - create/update and schedule all executor tests (with CLI)
         working-directory: ./testkube-repo
         run: chmod +x ./test/scripts/executor-tests/run.sh && ./test/scripts/executor-tests/run.sh -c -s # (create/update, schedule) - don't execute
 
-      - name: (Re)create Postman Sanity test (with CLI)
+      - name: Delete Postman Sanity test (with CLI)
         working-directory: ./testkube-repo
         run: |-
           # enabling debug mode
           set -x
           kubectl -n testkube delete test sanity --ignore-not-found=true
           kubectl -n testkube delete secret sanity-secrets --ignore-not-found=true
-          kubectl testkube create test -f ./test/postman/TestKube-Sanity.postman_collection.json --name sanity --type postman/collection -v api_uri=http://testkube-api-server:8088 -v test_api_uri=http://testkube-api-server:8088 -v test_type=postman/collection -v test_name=fill-me -v execution_name=fill-me
-          
-      - name: Run Postman sanity tests
-        run: kubectl testkube run test sanity -f
+      
+      - name: Create Postman Sanity test (action)
+        working-directory: ./testkube-repo
+        uses: kubeshop/testkube-docker-action@v1
+        with:
+          command: create
+          resource: test
+          parameters: "-f ./test/postman/TestKube-Sanity.postman_collection.json --name sanity --type postman/collection  -v api_uri=http://testkube-api-server:8088 -v test_api_uri=http://testkube-api-server:8088 -v test_type=postman/collection -v test_name=fill-me -v execution_name=fill-me"
 
-      - name: (Re)create Dashboard E2E tests (from CRD)
+      - name: Run Postman Sanity test (action)
+        id: run_test_suite
+        uses: kubeshop/testkube-docker-action@v1
+        with:
+          command: run
+          resource: test
+          parameters: "sanity -f"
+
+      - name: Create/update Dashboard E2E tests (from CRD)
         working-directory: ./testkube-repo
         run: |-
           # enabling debug mode
           set -x
-          kubectl -n testkube delete test dashboard-e2e-tests --ignore-not-found=true
           kubectl apply -f ./test/dashboard-e2e/crd/crd.yaml
 
       - name: (Re)create demo testsuite
@@ -284,38 +305,38 @@ jobs:
           kubectl -n testkube delete testsuite demo-testsuite --ignore-not-found=true
           kubectl testkube create testsuite -f ./test/suites/demo-testsuite.json --name demo-testsuite
 
-      - name: Run demo testsuite
+      - name: Run demo testsuite (CLI)
         run: kubectl testkube run testsuite demo-testsuite -f
 
-  notify_slack_if_test_suite_dev_succeeds:
-    runs-on: ubuntu-latest
-    needs: test_suite_run_dev
-    steps:
-      - name: Slack Notification if the test suite run on DEV GKS succeeded.
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: testkube-logs
-          SLACK_COLOR: ${{ needs.test_suite_run_dev.result }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_TITLE: Test suite successfully run against ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE :party_blob:!
-          SLACK_USERNAME: GitHub
-          SLACK_LINK_NAMES: true
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_FOOTER: "Kubeshop --> TestKube"
+  # notify_slack_if_test_suite_dev_succeeds:
+  #   runs-on: ubuntu-latest
+  #   needs: test_suite_run_dev
+  #   steps:
+  #     - name: Slack Notification if the test suite run on DEV GKS succeeded.
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_CHANNEL: testkube-logs
+  #         SLACK_COLOR: ${{ needs.test_suite_run_dev.result }} # or a specific color like 'good' or '#ff00ff'
+  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
+  #         SLACK_TITLE: Test suite successfully run against ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE :party_blob:!
+  #         SLACK_USERNAME: GitHub
+  #         SLACK_LINK_NAMES: true
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #         SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  notify_slack_if_test_suite_failed:
-    runs-on: ubuntu-latest
-    needs: test_suite_run_dev
-    if: always() && (needs.test_suite_run_dev.result == 'failure')
-    steps:
-      - name: Slack Notification if the test suite run on DEV GKS failed.
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: testkube-logs
-          SLACK_COLOR: ${{ needs.test_suite_run_dev.result }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_TITLE: Test suite FAILED to run on ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE! :boom:!
-          SLACK_USERNAME: GitHub
-          SLACK_LINK_NAMES: true
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_FOOTER: "Kubeshop --> TestKube"
+  # notify_slack_if_test_suite_failed:
+  #   runs-on: ubuntu-latest
+  #   needs: test_suite_run_dev
+  #   if: always() && (needs.test_suite_run_dev.result == 'failure')
+  #   steps:
+  #     - name: Slack Notification if the test suite run on DEV GKS failed.
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_CHANNEL: testkube-logs
+  #         SLACK_COLOR: ${{ needs.test_suite_run_dev.result }} # or a specific color like 'good' or '#ff00ff'
+  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
+  #         SLACK_TITLE: Test suite FAILED to run on ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE! :boom:!
+  #         SLACK_USERNAME: GitHub
+  #         SLACK_LINK_NAMES: true
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #         SLACK_FOOTER: "Kubeshop --> TestKube"

--- a/.github/workflows/helm-releaser-testkube-charts.yaml
+++ b/.github/workflows/helm-releaser-testkube-charts.yaml
@@ -275,15 +275,16 @@ jobs:
           kubectl -n testkube delete secret sanity-secrets --ignore-not-found=true
       
       - name: Create Postman Sanity test (action)
-        working-directory: ./testkube-repo
+        id: create_postman_sanity_test
         uses: kubeshop/testkube-docker-action@v1
+        working-directory: ./testkube-repo
         with:
           command: create
           resource: test
           parameters: "-f ./test/postman/TestKube-Sanity.postman_collection.json --name sanity --type postman/collection  -v api_uri=http://testkube-api-server:8088 -v test_api_uri=http://testkube-api-server:8088 -v test_type=postman/collection -v test_name=fill-me -v execution_name=fill-me"
 
       - name: Run Postman Sanity test (action)
-        id: run_test_suite
+        id: run_postman_sanity_test
         uses: kubeshop/testkube-docker-action@v1
         with:
           command: run

--- a/.github/workflows/helm-releaser-testkube-charts.yaml
+++ b/.github/workflows/helm-releaser-testkube-charts.yaml
@@ -223,7 +223,7 @@ jobs:
   test_suite_run_dev:
     name: test suite for DEV GKE.
     runs-on: ubuntu-latest
-    # needs: deploy-to-testkube-dev-gke
+    needs: deploy-to-testkube-dev-gke
     steps:
       # Setup gcloud CLI
       - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7

--- a/.github/workflows/helm-releaser-testkube-charts.yaml
+++ b/.github/workflows/helm-releaser-testkube-charts.yaml
@@ -1,15 +1,12 @@
 name: Releasing Helm charts.
 
-# on:
-#   push:
-#     paths:
-#       - "charts/testkube**"
-#       - "charts/testkube-api/**"
-#     branches:
-#       - main
-
 on:
-  pull_request:
+  push:
+    paths:
+      - "charts/testkube**"
+      - "charts/testkube-api/**"
+    branches:
+      - main
 
 env:
   PROJECT_ID: ${{ secrets.GKE_PROJECT }}
@@ -18,210 +15,210 @@ env:
   DEPLOYMENT_NAME: testkube # Add your deployment name here.
 
 jobs:
-  # release_charts:
-  #   runs-on: ubuntu-latest
+  release_charts:
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-  #     - name: Configure Git
-  #       run: |
-  #         git config user.name "$GITHUB_ACTOR"
-  #         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-  #     - name: Install Helm
-  #       uses: azure/setup-helm@v1
-  #       with:
-  #         version: v3.4.0
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
 
-  #     - name: Installing repositories
-  #       run: |
-  #         helm repo add helm-charts https://kubeshop.github.io/helm-charts
-  #         helm repo add bitnami https://charts.bitnami.com/bitnami
+      - name: Installing repositories
+        run: |
+          helm repo add helm-charts https://kubeshop.github.io/helm-charts
+          helm repo add bitnami https://charts.bitnami.com/bitnami
 
-  #     - name: Run chart-releaser
-  #       uses: helm/chart-releaser-action@v1.2.1
-  #       with:
-  #         charts_dir: charts
-  #       env:
-  #         CR_TOKEN: "${{ secrets.CI_BOT_TOKEN }}"
-  #         CR_SKIP_EXISTING: true
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.2.1
+        with:
+          charts_dir: charts
+        env:
+          CR_TOKEN: "${{ secrets.CI_BOT_TOKEN }}"
+          CR_SKIP_EXISTING: true
 
-  # notify_slack_if_helm_chart_release_fails:
-  #   runs-on: ubuntu-latest
-  #   needs: release_charts
-  #   if: always() && (needs.release_charts.result == 'failure')
-  #   steps:
-  #     - name: Slack Notification if Helm Release action failed
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: testkube-logs
-  #         SLACK_COLOR: ${{ needs.release_charts.result }} # or a specific color like 'good' or '#ff00ff'
-  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
-  #         SLACK_TITLE: Helm Chart release action failed :boom:!
-  #         SLACK_USERNAME: GitHub
-  #         SLACK_LINK_NAMES: true
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #         SLACK_FOOTER: "Kubeshop --> TestKube"
+  notify_slack_if_helm_chart_release_fails:
+    runs-on: ubuntu-latest
+    needs: release_charts
+    if: always() && (needs.release_charts.result == 'failure')
+    steps:
+      - name: Slack Notification if Helm Release action failed
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.release_charts.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Helm Chart release action failed :boom:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  # refreshing_gh_pages:
-  #   needs: release_charts
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Triggering refresh for GH-pages to make just released charts available
-  #       run: |
-  #         curl -s --fail --request POST \
-  #           --url https://api.github.com/repos/kubeshop/helm-charts/pages/builds \
-  #           --header "Authorization: Bearer $USER_TOKEN"
-  #       env:
-  #         # You must create a personal token with repo access as GitHub does
-  #         # not yet support server-to-server page builds.
-  #         USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+  refreshing_gh_pages:
+    needs: release_charts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Triggering refresh for GH-pages to make just released charts available
+        run: |
+          curl -s --fail --request POST \
+            --url https://api.github.com/repos/kubeshop/helm-charts/pages/builds \
+            --header "Authorization: Bearer $USER_TOKEN"
+        env:
+          # You must create a personal token with repo access as GitHub does
+          # not yet support server-to-server page builds.
+          USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
 
-  # checking_that_ghpages_updated:
-  #   needs: refreshing_gh_pages
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Making sure that they are abvailable now.
-  #       run: |
-  #         status=""
-  #         counter=0
-  #         while [[ $status != \"built\" ]]
-  #         do
-  #             status=$(curl -s \
-  #             -H "Accept: application/vnd.github.v3+json" \
-  #             https://api.github.com/repos/kubeshop/helm-charts/pages/builds/latest \
-  #             --header "Authorization: Bearer $USER_TOKEN" | jq .status)
-  #             echo "Checking latest GH pages build status --> $status"
-  #             sleep 5
+  checking_that_ghpages_updated:
+    needs: refreshing_gh_pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Making sure that they are abvailable now.
+        run: |
+          status=""
+          counter=0
+          while [[ $status != \"built\" ]]
+          do
+              status=$(curl -s \
+              -H "Accept: application/vnd.github.v3+json" \
+              https://api.github.com/repos/kubeshop/helm-charts/pages/builds/latest \
+              --header "Authorization: Bearer $USER_TOKEN" | jq .status)
+              echo "Checking latest GH pages build status --> $status"
+              sleep 5
 
-  #             counter=$(expr $counter + 1)
-  #             if [[ $status == \"errored\" ]] || [[ $counter == 120 ]]; then
-  #               echo "Something went wrong. Please check GH's pages issues."
-  #               exit 1
-  #             fi
-  #         done
-  #       env:
-  #         # You must create a personal token with repo access as GitHub does
-  #         # not yet support server-to-server page builds.
-  #         USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+              counter=$(expr $counter + 1)
+              if [[ $status == \"errored\" ]] || [[ $counter == 120 ]]; then
+                echo "Something went wrong. Please check GH's pages issues."
+                exit 1
+              fi
+          done
+        env:
+          # You must create a personal token with repo access as GitHub does
+          # not yet support server-to-server page builds.
+          USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
 
-  # notify_slack_if_release_succeeds:
-  #   runs-on: ubuntu-latest
-  #   needs: checking_that_ghpages_updated
-  #   steps:
-  #     - name: Slack Notification if the helm release pipeline succeeded.
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: testkube-logs
-  #         SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
-  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
-  #         SLACK_TITLE: Helm chart release succeed and GH pages got updated :party_blob:!
-  #         SLACK_USERNAME: GitHub
-  #         SLACK_LINK_NAMES: true
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #         SLACK_FOOTER: "Kubeshop --> TestKube"
+  notify_slack_if_release_succeeds:
+    runs-on: ubuntu-latest
+    needs: checking_that_ghpages_updated
+    steps:
+      - name: Slack Notification if the helm release pipeline succeeded.
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Helm chart release succeed and GH pages got updated :party_blob:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  # notify_slack_if_gh_pages_update_failed:
-  #   runs-on: ubuntu-latest
-  #   needs: checking_that_ghpages_updated
-  #   if: always() && (needs.checking_that_ghpages_updated.result == 'failure')
-  #   steps:
-  #     - name: Slack Notification if the helm release GH Pages failed.
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: testkube-logs
-  #         SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
-  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
-  #         SLACK_TITLE: Helm chart release failed on GH pages update! :boom:!
-  #         SLACK_USERNAME: GitHub
-  #         SLACK_LINK_NAMES: true
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #         SLACK_FOOTER: "Kubeshop --> TestKube"
+  notify_slack_if_gh_pages_update_failed:
+    runs-on: ubuntu-latest
+    needs: checking_that_ghpages_updated
+    if: always() && (needs.checking_that_ghpages_updated.result == 'failure')
+    steps:
+      - name: Slack Notification if the helm release GH Pages failed.
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Helm chart release failed on GH pages update! :boom:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  # deploy-to-testkube-dev-gke:
-  #   name: Deploy
-  #   runs-on: ubuntu-latest
-  #   needs: notify_slack_if_release_succeeds
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
+  deploy-to-testkube-dev-gke:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: notify_slack_if_release_succeeds
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-  #     - name: Configure Git
-  #       run: |
-  #         git config user.name "$GITHUB_ACTOR"
-  #         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-  #     # Setup gcloud CLI
-  #     - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
-  #       with:
-  #         service_account_key: ${{ secrets.GKE_SA_KEY }}
-  #         project_id: ${{ secrets.GKE_PROJECT }}
+      # Setup gcloud CLI
+      - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
+        with:
+          service_account_key: ${{ secrets.GKE_SA_KEY }}
+          project_id: ${{ secrets.GKE_PROJECT }}
 
-  #     # Configure Docker to use the gcloud command-line tool as a credential
-  #     # helper for authentication
-  #     - run: |-
-  #         gcloud --quiet auth configure-docker
+      # Configure Docker to use the gcloud command-line tool as a credential
+      # helper for authentication
+      - run: |-
+          gcloud --quiet auth configure-docker
 
-  #     # Get the GKE credentials so we can deploy to the cluster
-  #     - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
-  #       with:
-  #         cluster_name: ${{ env.GKE_CLUSTER_NAME_DEV }}
-  #         location: ${{ env.GKE_ZONE_DEV }}
-  #         credentials: ${{ secrets.GKE_SA_KEY }}
+      # Get the GKE credentials so we can deploy to the cluster
+      - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
+        with:
+          cluster_name: ${{ env.GKE_CLUSTER_NAME_DEV }}
+          location: ${{ env.GKE_ZONE_DEV }}
+          credentials: ${{ secrets.GKE_SA_KEY }}
 
-  #     - name: Install Helm
-  #       uses: azure/setup-helm@v1
-  #       with:
-  #         version: v3.4.0
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
 
-  #     - name: Installing repositories
-  #       run: |
-  #         helm repo add helm-charts https://kubeshop.github.io/helm-charts
-  #         helm repo add bitnami https://charts.bitnami.com/bitnami
+      - name: Installing repositories
+        run: |
+          helm repo add helm-charts https://kubeshop.github.io/helm-charts
+          helm repo add bitnami https://charts.bitnami.com/bitnami
 
-  #     # Deploy the Docker image to the GKE cluster
-  #     - name: Deploy
-  #       run: |-
-  #         helm upgrade --install --atomic --timeout 180s testkube helm-charts/testkube --namespace testkube --create-namespace --values ./charts/testkube/values-demo.yaml --debug --set testkube-api.cliIngress.oauth.clientID=${{ secrets.TESTKUBE_DEMO_OAUTH_CLIENT_ID }} --set testkube-api.cliIngress.oauth.clientSecret=${{ secrets.TESTKUBE_DEMO_OAUTH_CLIENT_SECRET }}
+      # Deploy the Docker image to the GKE cluster
+      - name: Deploy
+        run: |-
+          helm upgrade --install --atomic --timeout 180s testkube helm-charts/testkube --namespace testkube --create-namespace --values ./charts/testkube/values-demo.yaml --debug --set testkube-api.cliIngress.oauth.clientID=${{ secrets.TESTKUBE_DEMO_OAUTH_CLIENT_ID }} --set testkube-api.cliIngress.oauth.clientSecret=${{ secrets.TESTKUBE_DEMO_OAUTH_CLIENT_SECRET }}
 
-  # notify_slack_if_deploy_dev_succeeds:
-  #   runs-on: ubuntu-latest
-  #   needs: deploy-to-testkube-dev-gke
-  #   steps:
-  #     - name: Slack Notification if the helm release deployment to DEV GKS succeeded.
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: testkube-logs
-  #         SLACK_COLOR: ${{ needs.deploy-to-testkube-dev-gke.result }} # or a specific color like 'good' or '#ff00ff'
-  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
-  #         SLACK_TITLE: Helm chart release successfully deployed into ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE :party_blob:!
-  #         SLACK_USERNAME: GitHub
-  #         SLACK_LINK_NAMES: true
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #         SLACK_FOOTER: "Kubeshop --> TestKube"
+  notify_slack_if_deploy_dev_succeeds:
+    runs-on: ubuntu-latest
+    needs: deploy-to-testkube-dev-gke
+    steps:
+      - name: Slack Notification if the helm release deployment to DEV GKS succeeded.
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.deploy-to-testkube-dev-gke.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Helm chart release successfully deployed into ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE :party_blob:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  # notify_slack_if_deploy_dev_failed:
-  #   runs-on: ubuntu-latest
-  #   needs: deploy-to-testkube-dev-gke
-  #   if: always() && (needs.deploy-to-testkube-dev-gke.result == 'failure')
-  #   steps:
-  #     - name: Slack Notification if the helm release deployment to DEV GKS failed.
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: testkube-logs
-  #         SLACK_COLOR: ${{ needs.deploy-to-testkube-dev-gke.result }} # or a specific color like 'good' or '#ff00ff'
-  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
-  #         SLACK_TITLE: Helm chart release failed to deploy into ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE! :boom:!
-  #         SLACK_USERNAME: GitHub
-  #         SLACK_LINK_NAMES: true
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #         SLACK_FOOTER: "Kubeshop --> TestKube"
+  notify_slack_if_deploy_dev_failed:
+    runs-on: ubuntu-latest
+    needs: deploy-to-testkube-dev-gke
+    if: always() && (needs.deploy-to-testkube-dev-gke.result == 'failure')
+    steps:
+      - name: Slack Notification if the helm release deployment to DEV GKS failed.
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.deploy-to-testkube-dev-gke.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Helm chart release failed to deploy into ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE! :boom:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"
 
   test_suite_run_dev:
     name: test suite for DEV GKE.
@@ -290,35 +287,35 @@ jobs:
       - name: Run demo testsuite
         run: kubectl testkube run testsuite demo-testsuite -f
 
-  # notify_slack_if_test_suite_dev_succeeds:
-  #   runs-on: ubuntu-latest
-  #   needs: test_suite_run_dev
-  #   steps:
-  #     - name: Slack Notification if the test suite run on DEV GKS succeeded.
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: testkube-logs
-  #         SLACK_COLOR: ${{ needs.test_suite_run_dev.result }} # or a specific color like 'good' or '#ff00ff'
-  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
-  #         SLACK_TITLE: Test suite successfully run against ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE :party_blob:!
-  #         SLACK_USERNAME: GitHub
-  #         SLACK_LINK_NAMES: true
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #         SLACK_FOOTER: "Kubeshop --> TestKube"
+  notify_slack_if_test_suite_dev_succeeds:
+    runs-on: ubuntu-latest
+    needs: test_suite_run_dev
+    steps:
+      - name: Slack Notification if the test suite run on DEV GKS succeeded.
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.test_suite_run_dev.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Test suite successfully run against ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE :party_blob:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"
 
-  # notify_slack_if_test_suite_failed:
-  #   runs-on: ubuntu-latest
-  #   needs: test_suite_run_dev
-  #   if: always() && (needs.test_suite_run_dev.result == 'failure')
-  #   steps:
-  #     - name: Slack Notification if the test suite run on DEV GKS failed.
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: testkube-logs
-  #         SLACK_COLOR: ${{ needs.test_suite_run_dev.result }} # or a specific color like 'good' or '#ff00ff'
-  #         SLACK_ICON: https://github.com/rtCamp.png?size=48
-  #         SLACK_TITLE: Test suite FAILED to run on ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE! :boom:!
-  #         SLACK_USERNAME: GitHub
-  #         SLACK_LINK_NAMES: true
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #         SLACK_FOOTER: "Kubeshop --> TestKube"
+  notify_slack_if_test_suite_failed:
+    runs-on: ubuntu-latest
+    needs: test_suite_run_dev
+    if: always() && (needs.test_suite_run_dev.result == 'failure')
+    steps:
+      - name: Slack Notification if the test suite run on DEV GKS failed.
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.test_suite_run_dev.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Test suite FAILED to run on ${{ secrets.GKE_CLUSTER_NAME_DEV }} GKE! :boom:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"


### PR DESCRIPTION
Tests similar to the ones in staging workflow (https://github.com/kubeshop/helm-charts/pull/315)

- tests checkout from main testkube repo
- executor tests - test create/update, and schedule checks for all executor tests
- (re)creating Dashboard E2E tests (from CRD)
- Running Demo testsuite
- Postman and Dashboard tests creation is separated on purpose to check creation from CLI and CRD
- Postman Test isn't included in Demo testsuite to check both running a single test and testsuite
- kubectl delete changed from || true to --ignore-not-found=true


**Merge after:**
- [x] PR with `demo-testsuite`: https://github.com/kubeshop/testkube/pull/2696
- [x] Fix for testsuite follow (`-f`): https://github.com/kubeshop/testkube/pull/2694