### PR TITLE
fix: rename copy-files to uploads

### DIFF
--- a/charts/testkube-operator/templates/tests.testkube.io_tests.yaml
+++ b/charts/testkube-operator/templates/tests.testkube.io_tests.yaml
@@ -423,11 +423,6 @@ spec:
                       description: uri of test content
                       type: string
                   type: object
-                copyFiles:
-                  description: files to be copied from host of form source:destination
-                  items:
-                    type: string
-                  type: array
                 executionRequest:
                   description: test execution request body
                   properties:
@@ -624,6 +619,11 @@ spec:
                 type:
                   description: test type
                   type: string
+                uploads:
+                  description: files to be used from minio uploads
+                  items:
+                    type: string
+                  type: array
               type: object
             status:
               description: TestStatus defines the observed state of Test

--- a/charts/testkube-operator/templates/tests.testkube.io_testsuites.yaml
+++ b/charts/testkube-operator/templates/tests.testkube.io_testsuites.yaml
@@ -324,11 +324,6 @@ spec:
                         type: string
                     type: object
                   type: array
-                copyFiles:
-                  description: files to be copied from host of form source:destination
-                  items:
-                    type: string
-                  type: array
                 description:
                   type: string
                 executionRequest:


### PR DESCRIPTION
## Pull request description 

Rename copy files to uploads and removing it from test suites as it is not yet implemented

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-