### PR TITLE
feat: allow setting cloud params

### DIFF
--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -96,6 +96,14 @@ spec:
             value:  "{{ .Values.cliIngress.oauth.provider }}"
           - name: TESTKUBE_OAUTH_SCOPES
             value:  "{{ .Values.cliIngress.oauth.scopes }}"
+          {{- if .Values.cloud.key }}
+          - name: TESTKUBE_CLOUD_API_KEY
+            value:  "{{ .Values.cloud.key}}"
+          {{- end}}
+          {{- if .Values.cloud.url }}
+          - name: TESTKUBE_CLOUD_API_URL
+            value:  "{{ .Values.cloud.url}}"
+          {{- end}}
           {{- if .Values.extraEnvVars }}
           {{ include "testkube-api.extraVars" (dict "value" .Values.extraEnvVars "context" $) | nindent 10 | trim }}
           {{- end }}

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -26,6 +26,9 @@ mongodb:
   # or use dsn in secrets
   # secretName: testkube-secrets
   # secretKey: mongo-dsn
+cloud:
+  url: ""
+  key: ""
 postmanExecutorURI: "http://testkube-postman-executor:8082"
 
 analyticsEnabled: true


### PR DESCRIPTION
## Pull request description 

Tested with `helm template --set "cloud.url=1" --set "cloud.key=2" .`

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-