### PR TITLE
remove ingress annotations; added examples instead

### DIFF
--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -82,7 +82,8 @@ testkube-api:
     ## @param ingress.annotations [object] Additional annotations for the Ingress resource.
     ## e.g:
     ## annotations:
-    ##  kubernetes.io/ingress.class: nginx
+    ## kubernetes.io/ingress.class: nginx
+    ## nginx.ingress.kubernetes.io/rewrite-target: /$1
 
     path: /results/(v\d/executions.*)
     ## Hostnames must be provided if Ingress is enabled.

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -120,7 +120,7 @@ testkube-api:
     ##   nginx.ingress.kubernetes.io/ssl-redirect: "false"
     ##   nginx.ingress.kubernetes.io/configuration-snippet: |
     ##     more_set_headers "X-CLI-Ingress: true";
-    ##for websockets
+    ## for websockets
     ##   nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     ##   nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
 
@@ -193,7 +193,7 @@ testkube-dashboard:
     ##   nginx.ingress.kubernetes.io/enable-cors: "true"
     ##   nginx.ingress.kubernetes.io/cors-allow-methods: "GET"
     ##   nginx.ingress.kubernetes.io/cors-allow-credentials: "false"
-    ##github oauth annotations (empty by default)
+    ## github oauth annotations (empty by default)
     ##   nginx.ingress.kubernetes.io/auth-url: "http://$host/oauth2/auth"
     ##   nginx.ingress.kubernetes.io/auth-signin: "http://$host/oauth2/start?rd=$escaped_request_uri"
     ##   nginx.ingress.kubernetes.io/access-control-allow-origin: "*"

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -80,11 +80,23 @@ testkube-api:
   uiIngress:
     enabled: false
     ## @param ingress.annotations [object] Additional annotations for the Ingress resource.
-    ## e.g:
+    ## e.g annotations for NGINX Ingress Controller:
     ## annotations:
-    ## kubernetes.io/ingress.class: nginx
-    ## nginx.ingress.kubernetes.io/rewrite-target: /$1
-
+    ##   kubernetes.io/ingress.class: nginx
+    ##   nginx.ingress.kubernetes.io/rewrite-target: /$1
+    ##   nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    ##   nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    ##   nginx.ingress.kubernetes.io/enable-cors: "true"
+    ##   nginx.ingress.kubernetes.io/cors-allow-methods: "GET"
+    ##   nginx.ingress.kubernetes.io/cors-allow-credentials: "false"
+    ## github oauth annotations (empty by default)
+    ##   nginx.ingress.kubernetes.io/auth-url: "http://$host/oauth2/auth"
+    ##   nginx.ingress.kubernetes.io/auth-signin: "http://$host/oauth2/start?rd=$escaped_request_uri"
+    ##   nginx.ingress.kubernetes.io/auth-url: ""
+    ##   nginx.ingress.kubernetes.io/auth-signin: ""
+    ## for websockets
+    ##  nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    ##  nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     path: /results/(v\d/executions.*)
     ## Hostnames must be provided if Ingress is enabled.
     hosts:
@@ -100,10 +112,17 @@ testkube-api:
   cliIngress:
     enabled: false
     ## @param ingress.annotations [object] Additional annotations for the Ingress resource.
-    ## e.g:
+    ## e.g annotations for NGINX Ingress Controller:
     ## annotations:
     ##   kubernetes.io/ingress.class: nginx
     ##   nginx.ingress.kubernetes.io/rewrite-target: /$1
+    ##   nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    ##   nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    ##   nginx.ingress.kubernetes.io/configuration-snippet: |
+    ##     more_set_headers "X-CLI-Ingress: true";
+    ##for websockets
+    ##   nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    ##   nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
 
     # parameters to check oauth token (by default github one)
     oauth:
@@ -166,10 +185,21 @@ testkube-dashboard:
   ingress:
     enabled: false
     ## @param ingress.annotations [object] Additional annotations for the Ingress resource.
-    ## e.g:
+    ## e.g annotations for NGINX Ingress Controller:
     ## annotations:
-    ##  kubernetes.io/ingress.class: nginx
-    ##  nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    ##   kubernetes.io/ingress.class: nginx
+    ##   nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    ##   nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    ##   nginx.ingress.kubernetes.io/enable-cors: "true"
+    ##   nginx.ingress.kubernetes.io/cors-allow-methods: "GET"
+    ##   nginx.ingress.kubernetes.io/cors-allow-credentials: "false"
+    ##github oauth annotations (empty by default)
+    ##   nginx.ingress.kubernetes.io/auth-url: "http://$host/oauth2/auth"
+    ##   nginx.ingress.kubernetes.io/auth-signin: "http://$host/oauth2/start?rd=$escaped_request_uri"
+    ##   nginx.ingress.kubernetes.io/access-control-allow-origin: "*"
+    ##   nginx.ingress.kubernetes.io/auth-url: ""
+    ##   nginx.ingress.kubernetes.io/auth-signin: ""
+    ##   nginx.ingress.kubernetes.io/access-control-allow-origin: ""
     path: /
     ## Hostnames must be provided if Ingress is enabled.
     hosts:

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -79,22 +79,11 @@ testkube-api:
     storage: 10Gi
   uiIngress:
     enabled: false
-    annotations:
-      kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/rewrite-target: /$1
-      nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/enable-cors: "true"
-      nginx.ingress.kubernetes.io/cors-allow-methods: "GET"
-      nginx.ingress.kubernetes.io/cors-allow-credentials: "false"
-      # github oauth annotations (empty by default)
-      # nginx.ingress.kubernetes.io/auth-url: "http://$host/oauth2/auth"
-      # nginx.ingress.kubernetes.io/auth-signin: "http://$host/oauth2/start?rd=$escaped_request_uri"
-      nginx.ingress.kubernetes.io/auth-url: ""
-      nginx.ingress.kubernetes.io/auth-signin: ""
-      # for websockets
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-      nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    ## @param ingress.annotations [object] Additional annotations for the Ingress resource.
+    ## e.g:
+    ## annotations:
+    ##  kubernetes.io/ingress.class: nginx
+
     path: /results/(v\d/executions.*)
     ## Hostnames must be provided if Ingress is enabled.
     hosts:
@@ -109,16 +98,11 @@ testkube-api:
       #   secretName: testkube-cert-secret
   cliIngress:
     enabled: false
-    annotations:
-      kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/rewrite-target: /$1
-      nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/configuration-snippet: |
-        more_set_headers "X-CLI-Ingress: true";
-      # for websockets
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-      nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    ## @param ingress.annotations [object] Additional annotations for the Ingress resource.
+    ## e.g:
+    ## annotations:
+    ##   kubernetes.io/ingress.class: nginx
+    ##   nginx.ingress.kubernetes.io/rewrite-target: /$1
 
     # parameters to check oauth token (by default github one)
     oauth:
@@ -180,20 +164,11 @@ testkube-dashboard:
 #      value: BAR
   ingress:
     enabled: false
-    annotations:
-      kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/enable-cors: "true"
-      nginx.ingress.kubernetes.io/cors-allow-methods: "GET"
-      nginx.ingress.kubernetes.io/cors-allow-credentials: "false"
-      # github oauth annotations (empty by default)
-      # nginx.ingress.kubernetes.io/auth-url: "http://$host/oauth2/auth"
-      # nginx.ingress.kubernetes.io/auth-signin: "http://$host/oauth2/start?rd=$escaped_request_uri"
-      # nginx.ingress.kubernetes.io/access-control-allow-origin: "*"
-      nginx.ingress.kubernetes.io/auth-url: ""
-      nginx.ingress.kubernetes.io/auth-signin: ""
-      nginx.ingress.kubernetes.io/access-control-allow-origin: ""
+    ## @param ingress.annotations [object] Additional annotations for the Ingress resource.
+    ## e.g:
+    ## annotations:
+    ##  kubernetes.io/ingress.class: nginx
+    ##  nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     path: /
     ## Hostnames must be provided if Ingress is enabled.
     hosts:


### PR DESCRIPTION
## Pull request description 
Removed ingress annotations from values file so that they won't appear if users create a different type of ingress, except for nginx. 


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
