### PR TITLE
nat chart update

### DIFF
--- a/charts/testkube-operator/templates/deployment.yaml
+++ b/charts/testkube-operator/templates/deployment.yaml
@@ -36,6 +36,7 @@ spec:
         - --logtostderr=true
         - --v=10
         image: {{ include "global.images.image" (dict "imageRoot" .Values.proxy.image "global" .Values.global) }}
+        imagePullPolicy: {{ .Values.proxy.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.proxy.containerPort }}
           name: https

--- a/charts/testkube-operator/values.yaml
+++ b/charts/testkube-operator/values.yaml
@@ -48,6 +48,7 @@ proxy:
     registry: gcr.io
     repository: kubebuilder/kube-rbac-proxy
     tag: "v0.8.0"
+    pullPolicy: Always
   ## Proxy Container Port
   containerPort: 8443
 
@@ -155,7 +156,7 @@ webhook:
     ## image.pullPolicy patch container image pull policy
     image:
       registry: docker.io
-      repository: dpejcev/kube-webhook-certgen
+      repository: kubeshop/kube-webhook-certgen
       tag: 1.0.6
       pullPolicy: ""
     ## Annotations to add to the patch Job

--- a/charts/testkube/Chart.yaml
+++ b/charts/testkube/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
   - name: nats
     condition: testkube-api.nats.enabled
-    version: 0.17.5
+    version: 0.19.1
     repository: https://nats-io.github.io/k8s/helm/charts/
   - name: testkube-api
     version: 1.7.26

--- a/charts/testkube/templates/pre-upgrade.yaml
+++ b/charts/testkube/templates/pre-upgrade.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.preUpgradeHook.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -42,3 +43,4 @@ spec:
             fi
 
       restartPolicy: Never
+  {{- end }}

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -684,6 +684,7 @@ testkube-operator:
     enabled: true
 
 preUpgradeHook:
+  enabled: true
   name: mongodb-upgrade
   serviceAccount:
     create: true


### PR DESCRIPTION
## Pull request description
 
- upgrade NATS to `0.19.1` to include latest chart version;
- moved `webhook` image to kubeshop repository;
- added option to disable `mongo` upgarde.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes
Might be NATS upgrade, but it was tested.