### PR TITLE
adding .Values.oauth2.serviceType

### DIFF
--- a/charts/testkube-dashboard/templates/oauth2-service.yaml
+++ b/charts/testkube-dashboard/templates/oauth2-service.yaml
@@ -22,4 +22,5 @@ spec:
       name: http
   selector:
     {{- include "testkube-oauth2.selectorLabels" . | nindent 4 }}
+  type: {{ .Values.oauth2.serviceType }}
 {{- end }}

--- a/charts/testkube-dashboard/values.yaml
+++ b/charts/testkube-dashboard/values.yaml
@@ -143,6 +143,8 @@ oauth2:
   podAnnotations: {}
   ## Oauth2 Service annotations
   serviceAnnotations: {}
+  ## Oauth2 Service type
+  serviceType: ClusterIP
   ## image.registry Oauth image registry. Can be overridden by global parameters
   ## image.repository Oauth image name
   ## image.tag Oauth image tag

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -351,6 +351,8 @@ testkube-dashboard:
     annotations: {}
     ## Oauth2 Service annotations
     serviceAnnotations: {}
+    ## Oauth2 Service type
+    serviceType: ClusterIP
     ## Add additional labels to the pod (evaluated as a template)
     ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
     podLabels: {}


### PR DESCRIPTION
## Pull request description 
We need to change the oauth2 service type from ClusterIP to NodePort in GKE. So values should have it.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-