### PR TITLE
Update bitmani repo

### DIFF
--- a/.github/workflows/helm-deploy-testkube-charts-stage.yaml
+++ b/.github/workflows/helm-deploy-testkube-charts-stage.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Installing repositories
         run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add bitnami https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
 
       - name: Get image tag of Testkube APi, Dashboard, Operator
         id: vars

--- a/.github/workflows/helm-releaser-testkube-charts.yaml
+++ b/.github/workflows/helm-releaser-testkube-charts.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Installing repositories
         run: |
           helm repo add helm-charts https://kubeshop.github.io/helm-charts
-          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add bitnami https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.1
@@ -181,7 +181,7 @@ jobs:
       - name: Installing repositories
         run: |
           helm repo add helm-charts https://kubeshop.github.io/helm-charts
-          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add bitnami https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
 
       # Deploy the Docker image to the GKE cluster
       - name: Deploy

--- a/charts/testkube/Chart.yaml
+++ b/charts/testkube/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
   - name: mongodb
     condition: mongodb.enabled
     version: 11.0.0
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   - name: nats
     condition: testkube-api.nats.enabled
     version: 0.19.1


### PR DESCRIPTION
## Pull request description 

Bitnami uses a rotation script that cleans `index.yaml` file entries older than 6 months. The whole `index.yaml` is being generated and stored in GitHub. So if we want to keep using older versions for MongoDB we need to replace the existing repository (by default the one truncated every 6 months) with the path to the full file hosted in GitHub:

Replace this URL:
`repository: https://charts.bitnami.com/bitnami`
with this:
`repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami`

See the FAQ for this:  https://github.com/bitnami/charts/issues/10833


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-