### PR TITLE
feature(tracetest): allowing otlp access

### DIFF
--- a/charts/tracetest/templates/deployment.yaml
+++ b/charts/tracetest/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
             - name: http
               containerPort: {{ .Values.server.httpPort }}
               protocol: TCP
+            - name: otlp
+              containerPort: 21321
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /

--- a/charts/tracetest/templates/service.yaml
+++ b/charts/tracetest/templates/service.yaml
@@ -15,5 +15,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: 21321
+      targetPort: otlp
+      protocol: TCP
+      name: otlp
   selector:
     {{- include "tracetest.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
## Pull request description 
We need to expose the otlp ports from both the container and the service so the otel collector can reach out to tracetest.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

- Exposing tracetest otlp ports

## Fixes

- [[In-App Config] Installer Changes#1630](https://github.com/kubeshop/tracetest/issues/1630)