### PR TITLE
Allow the Liveness and Readiness Probe Initial Delay to be configured (default to existing value of 120 seconds)

### DIFF
--- a/charts/testkube-api/templates/minio.yaml
+++ b/charts/testkube-api/templates/minio.yaml
@@ -100,7 +100,7 @@ spec:
             httpGet:
               path: /minio/health/ready
               port: 9000
-            initialDelaySeconds: 120
+            initialDelaySeconds: {{ .Values.minio.initialDelaySeconds }}
             periodSeconds: 20
           # Liveness probe detects situations where MinIO server instance
           # is not working properly and needs restart. Kubernetes automatically
@@ -109,7 +109,7 @@ spec:
             httpGet:
               path: /minio/health/live
               port: 9000
-            initialDelaySeconds: 120
+            initialDelaySeconds: {{ .Values.minio.initialDelaySeconds }}
             periodSeconds: 20
           {{- if .Values.minio.resources }}
           resources: {{ toYaml .Values.minio.resources | nindent 12 }}

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -219,6 +219,8 @@ minio:
   matchLabels: []
   ## Resources limits and requests
   resources: {}
+  ## Wait 120 seconds before performing the first probe
+  initialDelaySeconds: 120
 
 ## uiIngress parameters
 uiIngress:

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -116,6 +116,8 @@ testkube-api:
     storage: 10Gi
     ## Resources limits and requests
     resources: {}
+    ## Wait 120 seconds before performing the first probe
+    initialDelaySeconds: 120
 
   ## uiIngress parameters
   uiIngress:


### PR DESCRIPTION
By default the minio pods will wait 120 seconds (2 minutes) before Kubernetes starts checking their readiness. This change allows the user to change this initial wait value but keeps the existing default.

Background: Waiting for 2 minutes before marking the Pods as ready slows down the startup on local deployments i.e. KinD