### PR TITLE
disable mongo probes for stage

### DIFF
--- a/.github/workflows/helm-deploy-testkube-charts-stage.yaml
+++ b/.github/workflows/helm-deploy-testkube-charts-stage.yaml
@@ -75,25 +75,25 @@ jobs:
         if: ${{ github.event.client_payload.image_tag_executor }}
         run: |
           helm dependency update ./charts/testkube
-          helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml  --set testkube-api.image.tag=${{ steps.vars.outputs.api_image_tag }} --set testkube-operator.image.tag=${{ steps.vars.outputs.operator_image_tag }} --set testkube-dashboard.image.tag=${{ steps.vars.outputs.dashboard_image_tag }} --set testkube-api.minio.storage=80Gi
+          helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml  --set testkube-api.image.tag=${{ steps.vars.outputs.api_image_tag }} --set testkube-operator.image.tag=${{ steps.vars.outputs.operator_image_tag }} --set testkube-dashboard.image.tag=${{ steps.vars.outputs.dashboard_image_tag }} --set testkube-api.minio.storage=80Gi --set mongodb.livenessProbe.enabled=false --set mongodb.reasdinessProbe.enabled=false
 
       - name: Deploy if Testkube API image is updated
         if: ${{ github.event.client_payload.image_tag }}
         run: |
           helm dependency update ./charts/testkube
-          helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml --set testkube-api.image.tag=${{ github.event.client_payload.image_tag }} --set testkube-operator.image.tag=${{ steps.vars.outputs.operator_image_tag }} --set testkube-dashboard.image.tag=${{ steps.vars.outputs.dashboard_image_tag }} --set testkube-api.minio.storage=80Gi
+          helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml --set testkube-api.image.tag=${{ github.event.client_payload.image_tag }} --set testkube-operator.image.tag=${{ steps.vars.outputs.operator_image_tag }} --set testkube-dashboard.image.tag=${{ steps.vars.outputs.dashboard_image_tag }} --set testkube-api.minio.storage=80Gi --set mongodb.livenessProbe.enabled=false --set mongodb.reasdinessProbe.enabled=false
 
       - name: Deploy if Testkube Dashboard image is updated
         if: ${{ github.event.client_payload.image_tag_dashboard }}
         run: |
           helm dependency update ./charts/testkube
-          helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml --set testkube-dashboard.image.tag=${{ github.event.client_payload.image_tag_dashboard }} --set testkube-operator.image.tag=${{ steps.vars.outputs.operator_image_tag }} --set testkube-api.image.tag=${{ steps.vars.outputs.api_image_tag }} --set testkube-api.minio.storage=80Gi
+          helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml --set testkube-dashboard.image.tag=${{ github.event.client_payload.image_tag_dashboard }} --set testkube-operator.image.tag=${{ steps.vars.outputs.operator_image_tag }} --set testkube-api.image.tag=${{ steps.vars.outputs.api_image_tag }} --set testkube-api.minio.storage=80Gi --set mongodb.livenessProbe.enabled=false --set mongodb.reasdinessProbe.enabled=false
 
       - name: Deploy if Testkube Operator image is updated
         if: ${{ github.event.client_payload.image_tag_operator }}
         run: |
           helm dependency update ./charts/testkube
-          helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml --set testkube-operator.image.tag=${{ github.event.client_payload.image_tag_operator }} --set testkube-dashboard.image.tag=${{ steps.vars.outputs.dashboard_image_tag }} --set testkube-api.image.tag=${{ steps.vars.outputs.api_image_tag }} --set testkube-api.minio.storage=80Gi
+          helm upgrade --debug --install --atomic --timeout 180s ${{ env.DEPLOYMENT_NAME }} ./charts/testkube --namespace ${{ env.DEPLOYMENT_NAME }} --create-namespace  --values ./charts/testkube/values-${{ env.ENV }}.yaml --set testkube-operator.image.tag=${{ github.event.client_payload.image_tag_operator }} --set testkube-dashboard.image.tag=${{ steps.vars.outputs.dashboard_image_tag }} --set testkube-api.image.tag=${{ steps.vars.outputs.api_image_tag }} --set testkube-api.minio.storage=80Gi --set mongodb.livenessProbe.enabled=false --set mongodb.reasdinessProbe.enabled=false
 
   notify_slack_if_deploy_stage_succeeds:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Pull request description 
mongodb CPU resource usage is very high in chart 12.0.0. As a workaround we disable `liveness` and `readiness` probes to avoid that. Now it's using around `255m` of CPU and  `342Mi` of memory

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-