### PR TITLE
update path for api

### DIFF
--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -196,7 +196,7 @@ testkube-api:
     ## for websockets
     ##  nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     ##  nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
-    path: /results/(v\d/executions.*)
+    path: /results/v1
     ## Hostnames must be provided if Ingress is enabled.
     hosts:
       - testkube.example.com
@@ -231,7 +231,7 @@ testkube-api:
       clientSecret: ""
       provider: "github"
       scopes: ""
-    path: /results/(v\d/.*)
+    path: /results/v1
     ## Hostnames must be provided if Ingress is enabled.
     hosts:
       - testkube.example.com


### PR DESCRIPTION
## Pull request description 
Since we always put `/results/v1` path as API enpoint in Dashboard UI I think it'll be clearer for the users to put the same in the `values.yaml` file. Moreover, `*` is not accepted by AWS Ingress Controller and gives an error during deployment, so the users have to update it manually and for some of them it is quite challenging and requires much time. 


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-