### PR TITLE
Support image digest in all testkube images

### DIFF
--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -163,7 +163,7 @@ spec:
             {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: {{ include "testkube-api.image" . }}
+          image: {{ include "global.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/testkube-dashboard/Chart.yaml
+++ b/charts/testkube-dashboard/Chart.yaml
@@ -4,3 +4,8 @@ description: A Helm chart for Kubernetes
 type: application
 version: 1.9.2-beta1
 appVersion: 1.9.2-beta1
+dependencies:
+  - name: global
+    version: 0.1.0
+    #repository: https://kubeshop.github.io/helm-charts
+    repository: "file://../global"

--- a/charts/testkube-dashboard/templates/deployment.yaml
+++ b/charts/testkube-dashboard/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: {{ include "testkube-dashboard.image" . }}
+          image: {{ include "global.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/testkube-operator/templates/deployment.yaml
+++ b/charts/testkube-operator/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: {{ include "testkube-operator.image" . }}
+        image: {{ include "global.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         livenessProbe:
           httpGet:


### PR DESCRIPTION
I tested using the following chart values and the digests were set on these 3 images.

```
testkube-api:
  image:
    digest: sha256:c41e2e48f1eded662d4ebc034b38eeaf0630a79a8bf26a1b4b1e26f60d73f848
testkube-dashboard:
  image:
    digest: sha256:9af03ed81101704010219fcd1f40bc73bc390a7966ec8a63d90277ec9af3ca0a
testkube-operator:
  image:
    digest: sha256:06545b9cf9f29773ab9c3144bb4c3ca5d7b675584589b9ee4c0531352a4e708d

```