### PR TITLE
update imagePullSecrets

### DIFF
--- a/charts/global/Chart.yaml
+++ b/charts/global/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.1.0
+version: 0.1.1
 name: global
 description: A Library Helm Chart for definitions that can be shared by Helm templates in other charts.
 home: https://github.com/kubeshop/helm-charts/tree/main/charts/global
@@ -20,4 +20,4 @@ sources:
   - https://github.com/kubeshop/helm-charts
   - https://testkube.io/
 
-appVersion: "0.1.0"
+appVersion: "0.1.1"

--- a/charts/global/templates/_images.tpl
+++ b/charts/global/templates/_images.tpl
@@ -20,3 +20,17 @@ Return the proper image name
 {{- end -}}
 
 
+{{/*
+Return the proper Docker Image Registry Secret Names evaluating values as templates
+{{ include "global.images.renderPullSecrets" . }}
+*/}}
+{{- define "global.images.renderPullSecrets" -}}
+{{- $global := .Values.global }}
+
+{{- if $global.imagePullSecrets }}
+imagePullSecrets:
+    {{- range $global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/testkube-api/Chart.yaml
+++ b/charts/testkube-api/Chart.yaml
@@ -6,6 +6,6 @@ version: 1.9.22
 appVersion: 1.9.22
 dependencies:
   - name: global
-    version: 0.1.0
+    version: 0.1.1
     #repository: https://kubeshop.github.io/helm-charts
     repository: "file://../global"

--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -28,10 +28,7 @@ spec:
           {{- include "global.tplvalues.render" ( dict "value" .Values.podLabels "context" $ ) | nindent 8 }}
           {{- end }}
     spec:
-      {{- with .Values.global.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "global.images.renderPullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "testkube-api.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/testkube-api/templates/minio.yaml
+++ b/charts/testkube-api/templates/minio.yaml
@@ -65,6 +65,7 @@ spec:
               mountPath: "/data"
           # Pulls the lastest Minio image from Docker Hub
           image: {{ include "global.images.image" (dict "imageRoot" .Values.minio.image "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.minio.image.pullPolicy }}
           args:
             - server
             - /data

--- a/charts/testkube-api/templates/minio.yaml
+++ b/charts/testkube-api/templates/minio.yaml
@@ -48,10 +48,7 @@ spec:
       # This label is used as a selector in Service definition
         app: testkube-minio-{{ .Release.Namespace }}
     spec:
-      {{- with .Values.global.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "global.images.renderPullSecrets" . | nindent 6 }}
       # Volumes used by this deployment
       volumes:
         - name: data

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -213,7 +213,7 @@ minio:
     registry: docker.io
     repository: minio/minio
     tag: latest
-
+    pullPolicy: Always
   ## ServiceAccount name to use for Minio
   serviceAccountName: ""
   ## Root username

--- a/charts/testkube-dashboard/Chart.yaml
+++ b/charts/testkube-dashboard/Chart.yaml
@@ -4,3 +4,8 @@ description: A Helm chart for Kubernetes
 type: application
 version: 1.9.2-beta1
 appVersion: 1.9.2-beta1
+dependencies:
+  - name: global
+    version: 0.1.1
+    #repository: https://kubeshop.github.io/helm-charts
+    repository: "file://../global"

--- a/charts/testkube-dashboard/templates/deployment.yaml
+++ b/charts/testkube-dashboard/templates/deployment.yaml
@@ -28,10 +28,7 @@ spec:
         {{- include "global.tplvalues.render" ( dict "value" .Values.podLabels "context" $ ) | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.global.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "global.images.renderPullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "testkube-dashboard.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/testkube-dashboard/templates/oauth2-deployment.yaml
+++ b/charts/testkube-dashboard/templates/oauth2-deployment.yaml
@@ -34,10 +34,7 @@ spec:
       annotations: {{- include "global.tplvalues.render" ( dict "value" .Values.oauth2.podAnnotations "context" $ ) | nindent 8 }}
       {{- end }}
     spec:
-      {{- with .Values.global.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "global.images.renderPullSecrets" . | nindent 6 }}
       containers:
       - args:
         {{- if .Values.oauth2.args }}

--- a/charts/testkube-operator/Chart.yaml
+++ b/charts/testkube-operator/Chart.yaml
@@ -6,6 +6,6 @@ version: 1.9.3
 appVersion: 1.9.3
 dependencies:
   - name: global
-    version: 0.1.0
+    version: 0.1.1
     #repository: https://kubeshop.github.io/helm-charts
     repository: "file://../global"

--- a/charts/testkube-operator/templates/deployment.yaml
+++ b/charts/testkube-operator/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         {{- include "global.tplvalues.render" ( dict "value" .Values.podLabels "context" $ ) | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.global.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "global.images.renderPullSecrets" . | nindent 6 }}
       containers:
       - name: kube-rbac-proxy
         args:

--- a/charts/testkube-operator/templates/webhook-cert-create.yaml
+++ b/charts/testkube-operator/templates/webhook-cert-create.yaml
@@ -41,11 +41,8 @@ spec:
         {{- include "global.tplvalues.render" ( dict "value" .Values.global.labels "context" $ ) | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.global.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- if .Values.webhook.migrate.enabled }}
+      {{- include "global.images.renderPullSecrets" . | nindent 6 }}
       initContainers:
         - name: migrate
           image: {{ include "global.images.image" (dict "imageRoot" .Values.webhook.migrate.image "global" .Values.global) }}

--- a/charts/testkube-operator/templates/webhook-cert-patch.yaml
+++ b/charts/testkube-operator/templates/webhook-cert-patch.yaml
@@ -41,10 +41,7 @@ spec:
         {{- include "global.tplvalues.render" ( dict "value" .Values.global.labels "context" $ ) | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.global.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "global.images.renderPullSecrets" . | nindent 6 }}
       containers:
         - name: patch
           image: {{ include "global.images.image" (dict "imageRoot" .Values.webhook.patch.image "global" .Values.global) }}

--- a/charts/testkube/Chart.yaml
+++ b/charts/testkube/Chart.yaml
@@ -26,6 +26,6 @@ dependencies:
     repository: "file://../testkube-dashboard"
     condition: testkube-dashboard.enabled
   - name: global
-    version: 0.1.0
+    version: 0.1.1
     #repository: https://kubeshop.github.io/helm-charts
     repository: "file://../global"

--- a/charts/testkube/templates/pre-upgrade.yaml
+++ b/charts/testkube/templates/pre-upgrade.yaml
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/name: "{{ .Values.preUpgradeHook.name }}"
     spec:
       serviceAccountName: "{{ .Values.preUpgradeHook.name }}"
+      {{- include "global.images.renderPullSecrets" . | nindent 6 }}
       containers:
       - name: kubectl
         image: "k8s.gcr.io/hyperkube:v1.12.1"

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -9,7 +9,8 @@
 ## global.annotations Annotations to add to all deployed objects
 global:
   imageRegistry: ""
-  imagePullSecrets: []
+  imagePullSecrets:
+    - secretsssssssssss
   labels: {}
   annotations: {}
 
@@ -51,8 +52,8 @@ mongodb:
   ## More info: https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-arm-workloads-for-deployment#node-affinity-multi-arch-arm
 nats:
   ## example on how to pass secrets to NATS deployment
-  #imagePullSecrets:
-  #  - name: secret
+#  imagePullSecrets:
+#    - name: secret
   tolerations:
     - key: kubernetes.io/arch
       operator: Equal

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -9,8 +9,7 @@
 ## global.annotations Annotations to add to all deployed objects
 global:
   imageRegistry: ""
-  imagePullSecrets:
-    - secretsssssssssss
+  imagePullSecrets: []
   labels: {}
   annotations: {}
 

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -50,6 +50,9 @@ mongodb:
   ## Tolerations to schedule a workload to nodes with any architecture type. Required for deployment to GKE cluster.
   ## More info: https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-arm-workloads-for-deployment#node-affinity-multi-arch-arm
 nats:
+  ## example on how to pass secrets to NATS deployment
+  #imagePullSecrets:
+  #  - name: secret
   tolerations:
     - key: kubernetes.io/arch
       operator: Equal
@@ -61,6 +64,7 @@ nats:
         operator: Equal
         value: arm64
         effect: NoSchedule
+
 
 ### Testkube API parameters
 testkube-api:


### PR DESCRIPTION
## Pull request description 
Updated Testkube `imagePullSecrets` so that they are aligned with MongoDB chart and now we can use `global` parameter to define secrets across all resources, except for NATS. For NATS they are defined differently since the chart doesn't provide `global` section. Example is provided in the `values.yaml` file in commented section.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

- way we define `imagePullSecrets`

## Fixes

-