### PR TITLE
feat: allow custom probes for testkube-api (#417)

### DIFF
--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -167,13 +167,9 @@ spec:
               containerPort: 8088
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- toYaml .Values.readinessProbe | nindent 12 }}          
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -290,3 +290,26 @@ prometheus:
 ##Test Connection pod
 testConnection:
   enabled: false
+
+## Set custom livenessProbe
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+    scheme: HTTP
+  failureThreshold: 3              
+  initialDelaySeconds: 180
+  periodSeconds: 30
+  successThreshold: 1
+  timeoutSeconds: 10 
+
+## Set custom readinessProbe
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  failureThreshold: 3              
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  successThreshold: 1
+  timeoutSeconds: 10    

--- a/charts/testkube/values-demo.yaml
+++ b/charts/testkube/values-demo.yaml
@@ -255,6 +255,42 @@ testkube-api:
     # secretKey: mongo-dsn
     allowDiskUse: true
 
+  ## Set custom livenessProbe
+  livenessProbe:
+    ## Probe type
+    httpGet:
+      path: /health
+      port: http
+      scheme: HTTP
+    ## Amount of request failures before the container receives a terminate signal
+    failureThreshold: 3 
+    ## Time to wait after the initial deployment before performing first probe            
+    initialDelaySeconds: 180
+    ## How often (in seconds) to perform the probes. This value sends one probe every 30 seconds
+    periodSeconds: 30
+    ## Minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    ## Number of seconds after which the probe times out
+    timeoutSeconds: 10 
+
+  ## Set custom readinessProbe
+  readinessProbe:
+    ## Probe type
+    httpGet:
+      path: /health
+      port: http
+      scheme: HTTP
+    ## Amount of request failures before the container receives a terminate signal
+    failureThreshold: 3 
+    ## Time to wait after the initial deployment before performing first probe            
+    initialDelaySeconds: 60
+    ## How often (in seconds) to perform the probes. This value sends one probe every 30 seconds
+    periodSeconds: 30
+    ## Minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    ## Number of seconds after which the probe times out
+    timeoutSeconds: 10     
+
   analyticsEnabled: true
   slackToken: ""
   slackSecret: ""

--- a/charts/testkube/values-stage.yaml
+++ b/charts/testkube/values-stage.yaml
@@ -237,6 +237,42 @@ testkube-api:
     # secretKey: mongo-dsn
     allowDiskUse: true
 
+  ## Set custom livenessProbe
+  livenessProbe:
+    ## Probe type
+    httpGet:
+      path: /health
+      port: http
+      scheme: HTTP
+    ## Amount of request failures before the container receives a terminate signal
+    failureThreshold: 3 
+    ## Time to wait after the initial deployment before performing first probe            
+    initialDelaySeconds: 180
+    ## How often (in seconds) to perform the probes. This value sends one probe every 30 seconds
+    periodSeconds: 30
+    ## Minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    ## Number of seconds after which the probe times out
+    timeoutSeconds: 10 
+
+  ## Set custom readinessProbe
+  readinessProbe:
+    ## Probe type
+    httpGet:
+      path: /health
+      port: http
+      scheme: HTTP
+    ## Amount of request failures before the container receives a terminate signal
+    failureThreshold: 3 
+    ## Time to wait after the initial deployment before performing first probe            
+    initialDelaySeconds: 60
+    ## How often (in seconds) to perform the probes. This value sends one probe every 30 seconds
+    periodSeconds: 30
+    ## Minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    ## Number of seconds after which the probe times out
+    timeoutSeconds: 10     
+
   analyticsEnabled: true
   slackToken: ""
   slackSecret: ""

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -283,6 +283,42 @@ testkube-api:
     # secretKey: mongo-dsn
     allowDiskUse: true
 
+  ## Set custom livenessProbe
+  livenessProbe:
+    ## Probe type
+    httpGet:
+      path: /health
+      port: http
+      scheme: HTTP
+    ## Amount of request failures before the container receives a terminate signal
+    failureThreshold: 3 
+    ## Time to wait after the initial deployment before performing first probe            
+    initialDelaySeconds: 180
+    ## How often (in seconds) to perform the probes. This value sends one probe every 30 seconds
+    periodSeconds: 30
+    ## Minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    ## Number of seconds after which the probe times out
+    timeoutSeconds: 10 
+
+  ## Set custom readinessProbe
+  readinessProbe:
+    ## Probe type
+    httpGet:
+      path: /health
+      port: http
+      scheme: HTTP
+    ## Amount of request failures before the container receives a terminate signal
+    failureThreshold: 3 
+    ## Time to wait after the initial deployment before performing first probe            
+    initialDelaySeconds: 60
+    ## How often (in seconds) to perform the probes. This value sends one probe every 30 seconds
+    periodSeconds: 30
+    ## Minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    ## Number of seconds after which the probe times out
+    timeoutSeconds: 10      
+
   ## Enable analytics for Testkube
   analyticsEnabled: true
 


### PR DESCRIPTION
## Pull request description 
This allows the configuration of custom liveness and readiness probes for the testkube-api


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

No breaking changes.

## Changes

- Templated liveness and readiness probes in testkube-api deployment to allow custom values

## Fixes
#417 