### PR TITLE
fix:rolebinding references to match role names in operator

### DIFF
--- a/charts/testkube-operator/templates/rolebinding.yaml
+++ b/charts/testkube-operator/templates/rolebinding.yaml
@@ -15,7 +15,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: testkube-operator-manager-role
+  name: {{ .Release.Name }}-operator-manager-role
 subjects:
 - kind: ServiceAccount
   name: {{ include "testkube-operator.serviceAccountName" . }}
@@ -37,7 +37,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: testkube-operator-proxy-role
+  name: {{ .Release.Name }}-operator-proxy-role
 subjects:
 - kind: ServiceAccount
   name: {{ include "testkube-operator.serviceAccountName" . }}
@@ -60,7 +60,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Namespace }}-operator-leader-election-role
+  name: {{ .Release.Name }}-operator-leader-election-role
 subjects:
 - kind: ServiceAccount
   name: {{ include "testkube-operator.serviceAccountName" . }}


### PR DESCRIPTION
## Pull request description 

Fixes the RoleBinding refs to Roles to match the correct names, in testkube-operator

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

No breaking changes.

## Changes

* Change names of RoleBinding/ClusterRoleBinding references for roles "-operator-manager-role" , "-operator-proxy-role" and "-operator-leader-election-role"

## Fixes

-