### PR TITLE
Support adding annotations to the kubetest-api SA

### DIFF
--- a/charts/testkube-api/templates/serviceaccount.yaml
+++ b/charts/testkube-api/templates/serviceaccount.yaml
@@ -8,7 +8,11 @@ metadata:
     {{- if .Values.global.labels }}
     {{- include "global.tplvalues.render" ( dict "value" .Values.global.labels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.global.annotations}}
-  annotations: {{- include "global.tplvalues.render" ( dict "value" .Values.global.annotations "context" $ ) | nindent 4 }}
-  {{- end }}
+    {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.global.annotations }}
+    {{- include "global.tplvalues.render" ( dict "value" .Values.global.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- end }}


### PR DESCRIPTION
## Pull request description 

The `vaules.yaml` file for the kubetest-api chart allows for annotations to be set of the kubetest-api serviceAccount [here](https://github.com/kubeshop/helm-charts/blob/d861b662f38741c6ebfd8c1f4f8a711f8314a2ec/charts/testkube-api/values.yaml#L161) but as best I can tell they are never added to the serviceAccount.

This change copies the logic for setting serviceAccount annotations from the testkube-dashboard chart.

The ability to add an annotation to the testkube-api SA is important if you want to be able to direct testkube-api to use S3 storage instead of Minio.

https://docs.testkube.io/concepts/common-issues/#installation-with-s3-storage-and-iam-authentication

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

- Adds missing support for setting annotations on the testkube-api serviceAccount