### PR TITLE
fix: lint error for testkube chart

### DIFF
--- a/charts/testkube/templates/pre-upgrade-sa.yaml
+++ b/charts/testkube/templates/pre-upgrade-sa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.preUpgradeHook.serviceAccount.create -}}
+{{- if .Values.preUpgradeHook.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 
 ---
-{{- if .Values.preUpgradeHook.serviceAccount.create -}}
+{{- if .Values.preUpgradeHook.serviceAccount.create }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -30,7 +30,7 @@ rules:
 {{- end }}
 
 ---
-{{- if .Values.preUpgradeHook.serviceAccount.create -}}
+{{- if .Values.preUpgradeHook.serviceAccount.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:


### PR DESCRIPTION
## Pull request description 


Before:

``` 
$ helm lint 
==> Linting .
[INFO] Chart.yaml: icon is recommended
[ERROR] templates/pre-upgrade-sa.yaml: unable to parse YAML: invalid Yaml document separator: kind: Role
[ERROR] templates/pre-upgrade-sa.yaml: unable to parse YAML: invalid Yaml document separator: apiVersion: rbac.authorization.k8s.io/v1

Error: 1 chart(s) linted, 1 chart(s) failed
``` 

After
``` 
helm lint 
==> Linting .
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
``` 

See https://github.com/helm/helm/issues/10149#issuecomment-929205040

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-