### PR TITLE
option to add volumes

### DIFF
--- a/charts/testkube-dashboard/templates/oauth2-deployment.yaml
+++ b/charts/testkube-dashboard/templates/oauth2-deployment.yaml
@@ -74,6 +74,14 @@ spec:
         ports:
         - containerPort: {{ .Values.oauth2.port }}
           protocol: TCP
+        {{- with .Values.oauth2.volumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
+      {{- with .Values.oauth2.volumes }}
+      volumes:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- with .Values.oauth2.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/testkube-dashboard/templates/oauth2-deployment.yaml
+++ b/charts/testkube-dashboard/templates/oauth2-deployment.yaml
@@ -76,11 +76,11 @@ spec:
           protocol: TCP
         {{- with .Values.oauth2.volumeMounts }}
         volumeMounts:
-          {{- toYaml . | nindent 8 }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
       {{- with .Values.oauth2.volumes }}
       volumes:
-        {{- toYaml . | nindent 6 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.oauth2.nodeSelector }}
       nodeSelector:

--- a/charts/testkube-dashboard/values.yaml
+++ b/charts/testkube-dashboard/values.yaml
@@ -177,7 +177,16 @@ oauth2:
   ## Add additional Ingress labels
   ingress:
     labels: {}
-
+  ## Add volumes for Oauth2
+  volumes: []
+#  - name: test-volume
+#    gcePersistentDisk:
+#      pdName: my-data-disk
+#      fsType: ext4
+  ## Add volumeMounts for Oauth2
+  volumeMounts: []
+#  - mountPath: /mypath
+#    name: git-volume
 ## Testkube Dashboard resource requests and limits
 resources: {}
 #   limits:

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -594,7 +594,19 @@ testkube-dashboard:
     ingress:
       labels: {}
       # -- add Ingress annotations
-      annotations: {} 
+      annotations: {}
+
+    ## -- Add volumes for Oauth2
+    volumes: []
+    #  - name: test-volume
+    #    gcePersistentDisk:
+    #      pdName: my-data-disk
+    #      fsType: ext4
+
+    ## Add volumeMounts for Oauth2
+    volumeMounts: []
+    #  - mountPath: /mypath
+    #    name: git-volume
 
   # Autoscaling parameters
   autoscaling:


### PR DESCRIPTION
## Pull request description 
Added an option to specify volumes for oauth2 deployment, as requested in [issue](https://github.com/kubeshop/helm-charts/issues/447).


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-