### PR TITLE
adding missing quotes for the TRACETEST_DEV env variable

### DIFF
--- a/charts/tracetest/templates/deployment.yaml
+++ b/charts/tracetest/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           env:
           - name: TRACETEST_DEV
-            value: {{ .Values.env.tracetestDev }}
+            value: "{{ .Values.env.tracetestDev }}"
           args:
           - --config
           - '/app/config/config.yaml'


### PR DESCRIPTION
## Pull request description 
Fixes the Tracetest heml charts as the expected value is a string but we are passing it as boolean

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

- Fixes the Tracetest heml charts as the expected value is a string but we are passing it as boolean