### PR TITLE
fix:clear naming in operator pre upgrade resources

### DIFF
--- a/charts/testkube-operator/templates/pre-upgrade-sa.yaml
+++ b/charts/testkube-operator/templates/pre-upgrade-sa.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "testkube-operator.namespace" . }}
+  name: {{ .Release.Name }}-operator-pre-upgrade-sa
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
@@ -12,7 +12,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "testkube-operator.namespace" . }}
+  name: {{ .Release.Name }}-operator-pre-upgrade-role
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-weight": "3"
@@ -26,7 +26,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "testkube-operator.namespace" . }}
+  name: {{ .Release.Name }}-operator-pre-upgrade-rolebinding
   namespace: {{ include "testkube-operator.namespace" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
@@ -35,8 +35,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "testkube-operator.namespace" . }}
+  name: {{ .Release.Name }}-operator-pre-upgrade-role
 subjects:
   - kind: ServiceAccount
-    name: {{ include "testkube-operator.namespace" . }}
+    name: {{ .Release.Name }}-operator-pre-upgrade-sa
     namespace: {{ .Release.Namespace }}

--- a/charts/testkube-operator/templates/pre-upgrade.yaml
+++ b/charts/testkube-operator/templates/pre-upgrade.yaml
@@ -1,10 +1,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "testkube-operator.namespace" . }}
+  name: {{ .Release.Name }}-operator-pre-upgrade
   labels:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    job-name: {{ include "testkube-operator.namespace" . }}
+    job-name: {{ .Release.Name }}-operator-pre-upgrade
   annotations:
     "helm.sh/hook": pre-upgrade, pre-install
     "helm.sh/hook-weight": "4"
@@ -12,12 +12,12 @@ metadata:
 spec:
   template:
     metadata:
-      name: {{ include "testkube-operator.namespace" . }}
+      name: {{ .Release.Name }}-operator-pre-upgrade
       labels:
         app.kubernetes.io/component: testkube-operator
-        app.kubernetes.io/name: {{ include "testkube-operator.namespace" . }}
+        app.kubernetes.io/name: {{ .Release.Name }}-operator-pre-upgrade
     spec:
-      serviceAccountName: {{ include "testkube-operator.namespace" . }}
+      serviceAccountName:  {{ .Release.Name }}-operator-pre-upgrade-sa
       containers:
       - name: kubectl
         image: {{ include "global.images.image" (dict "imageRoot" .Values.preUpgrade.image "global" .Values.global) }}


### PR DESCRIPTION
## Pull request description 

Fixes the naming of pre-upgrade operator resources to be more descriptive and avoid issues with other resources in the cluster due to naming collision. 

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-