### PR TITLE
fix: allow configuring imagePullSecret in upgrade operator jobs

### DIFF
--- a/charts/testkube-operator/templates/pre-upgrade-sa.yaml
+++ b/charts/testkube-operator/templates/pre-upgrade-sa.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.preUpgrade.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,8 +8,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "3"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{- end }}
 
 ---
+{{- if .Values.preUpgrade.serviceAccount.create }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -21,8 +24,10 @@ rules:
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["create","delete","get","list","patch","update","watch"]
+{{- end }}
 
 ---
+{{- if .Values.preUpgrade.serviceAccount.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -40,3 +45,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-operator-pre-upgrade-sa
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/testkube-operator/templates/pre-upgrade.yaml
+++ b/charts/testkube-operator/templates/pre-upgrade.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.preUpgrade.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -18,10 +19,14 @@ spec:
         app.kubernetes.io/name: {{ .Release.Name }}-operator-pre-upgrade
     spec:
       serviceAccountName:  {{ .Release.Name }}-operator-pre-upgrade-sa
+      {{- include "global.images.renderPullSecrets" . | nindent 6 }}
       containers:
       - name: kubectl
         image: {{ include "global.images.image" (dict "imageRoot" .Values.preUpgrade.image "global" .Values.global) }}
         imagePullPolicy: {{ .Values.preUpgrade.image.pullPolicy }}
+        {{- if .Values.preUpgrade.resources }}
+        resources: {{- toYaml .Values.preUpgrade.resources | nindent 10 }}
+        {{- end }}
         command:
         - /bin/bash
         - -c
@@ -32,4 +37,12 @@ spec:
               else
                 kubectl create namespace {{ include "testkube-operator.namespace" . }};
               fi
+        securityContext:
+          {{- toYaml .Values.preUpgrade.securityContext | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.preUpgrade.podSecurityContext | nindent 8 }}
       restartPolicy: Never
+      {{- if .Values.preUpgrade.tolerations }}
+      tolerations: {{ toYaml .Values.preUpgrade.tolerations | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/testkube-operator/values.yaml
+++ b/charts/testkube-operator/values.yaml
@@ -283,8 +283,29 @@ testConnection:
   enabled: false
 
 preUpgrade:
+  # -- Upgrade hook is enabled
+  enabled: true
+  # -- Specify image
   image:
     registry: k8s.gcr.io
     repository: hyperkube
     tag: v1.12.1
     pullPolicy: IfNotPresent
+  # -- Specify resource limits and requests
+  resources: {}
+  # -- Create SA for upgrade hook
+  serviceAccount:
+    create: true
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  # -- Upgrade Pod Security Context
+  podSecurityContext: {}
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  # -- Security Context for Upgrade kubectl container
+  securityContext: {}
+  # ref: https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-arm-workloads-for-deployment#node-affinity-multi-arch-arm
+  # -- Tolerations to schedule a workload to nodes with any architecture type. Required for deployment to GKE cluster.
+  tolerations:
+    - key: kubernetes.io/arch
+      operator: Equal
+      value: arm64
+      effect: NoSchedule


### PR DESCRIPTION

## Pull request description 

Allow configuring imagePullSecret in upgrade operator jobs and consistency changes to match other upgrade jobs

match configuration with:
https://github.com/kubeshop/helm-charts/blob/main/charts/testkube/templates/pre-upgrade.yaml

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-