### PR TITLE
Fix Tracetest OTLP Server port

### DIFF
--- a/charts/tracetest/templates/service.yaml
+++ b/charts/tracetest/templates/service.yaml
@@ -15,7 +15,7 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    - port: 21321
+    - port: {{ .Values.service.otlpPort }}
       targetPort: otlp
       protocol: TCP
       name: otlp

--- a/charts/tracetest/values.yaml
+++ b/charts/tracetest/values.yaml
@@ -159,6 +159,7 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 11633
+  otlpPort: 4317
   annotations: {}
 
 ingress:


### PR DESCRIPTION
## Pull request description 

This PR fixes the HTTP port that the internal OTLP Server uses on Tracetest.

## Checklist (choose what happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Fixes

- https://github.com/kubeshop/tracetest/issues/2143