### PR TITLE
Fix tracetest ingress configuration

### DIFF
--- a/charts/tracetest/Chart.yaml
+++ b/charts/tracetest/Chart.yaml
@@ -26,7 +26,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.51
+version: 0.2.52
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tracetest/templates/ingress.yaml
+++ b/charts/tracetest/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "tracetest.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
+{{- $svcPort := .Values.server.httpPort -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}


### PR DESCRIPTION
## Pull request description 

On #487 we centralized the Tracetest port configuration on `.Values.server` config, removing the duplicate info on `.Values.service`. However, when we did that we forgot to fix this information on the ingress controller. This PR aims to to that, changing the controller to use `.Values.server.httpPort`.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Fixes

- Tracetest ingress controller