### PR TITLE
[tracetest]  upgrade postgres version

### DIFF
--- a/charts/tracetest/Chart.yaml
+++ b/charts/tracetest/Chart.yaml
@@ -26,7 +26,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.53
+version: 0.2.54
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tracetest/values.yaml
+++ b/charts/tracetest/values.yaml
@@ -5,7 +5,7 @@ postgresql:
   enabled: true
   architecture: standalone
   image:
-    tag: 14.6.0-debian-11-r13
+    tag: 14.7.0-debian-11-r29
 
   # credentials for accessing the database
   auth:


### PR DESCRIPTION
## Pull request description 

This PR upgrades postgres image tag to v14.7.0, which is the closest version that proves ARM64 docker images. This fixes https://github.com/kubeshop/tracetest/issues/2491

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-