### PR TITLE
[testkube-api] minio allow setting minio replicaCount

### DIFF
--- a/charts/testkube-api/templates/minio.yaml
+++ b/charts/testkube-api/templates/minio.yaml
@@ -29,6 +29,7 @@ metadata:
   annotations: {{- include "global.tplvalues.render" ( dict "value" .Values.global.annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  replicas: {{ .Values.minio.replicaCount }}
   selector:
     matchLabels:
       {{- if .Values.minio.matchLabels }}

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -222,6 +222,7 @@ nats:
 
 ## MINIO parameters
 minio:
+  replicaCount: 1
   ## Deploy Minio server to the cluster
   enabled: true
   ## Minio extra vars


### PR DESCRIPTION
## Pull request description 

In cloud we want to have an ability to change replica count to 0 (scale down) minio and scale it back up.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-