### PR TITLE
Tag: 1.11.2; testkube-dashboard CI/CD. Bumped helm chart, app and docker image tag versions.

### DIFF
--- a/charts/testkube-dashboard/Chart.yaml
+++ b/charts/testkube-dashboard/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: testkube-dashboard
 description: A Helm chart for Kubernetes
 type: application
-version: 1.10.6
-appVersion: 1.10.6
+version: 1.11.2
+appVersion: 1.11.2
 dependencies:
   - name: global
     version: 0.1.1

--- a/charts/testkube/Chart.yaml
+++ b/charts/testkube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: testkube
 description: Testkube is an open-source platform that simplifies the deployment and management of automated testing infrastructure.
 type: application
-version: 1.11.212
+version: 1.11.213
 dependencies:
   - name: testkube-operator
     version: 1.10.7
@@ -22,7 +22,7 @@ dependencies:
     #repository: https://kubeshop.github.io/helm-charts
     repository: "file://../testkube-api"
   - name: testkube-dashboard
-    version: 1.10.6
+    version: 1.11.2
     #repository: https://kubeshop.github.io/helm-charts
     repository: "file://../testkube-dashboard"
     condition: testkube-dashboard.enabled


### PR DESCRIPTION
Updated Testkube Dashbord to 1.11.2

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-