### PR TITLE
Set a sensible default for API server HTTP Read buffer size

### DIFF
--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -169,6 +169,10 @@ spec:
             - name: APISERVER_HTTP_BODY_LIMIT
               value: {{ .Values.httpBodyLimit }}
             {{- end}}
+            {{- if .Values.httpReadBufferSize }}
+            - name: APISERVER_HTTP_READBUFFERSIZE
+              value: {{ .Values.httpReadBufferSize }}
+            {{- end}}
             - name: TESTKUBE_OAUTH_CLIENTID
               value:  "{{ .Values.cliIngress.oauth.clientID }}"
             - name: TESTKUBE_OAUTH_CLIENTSECRET

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -341,3 +341,8 @@ readinessProbe:
 
 ## Testkube API HTTP body size limit
 ## httpBodyLimit: 1073741824
+
+## Testkube API HTTP Read buffer size (in bytes)
+## Might need further increase if observing "431 Request Header Fields Too Large from api server"
+##  See https://github.com/kubeshop/testkube/pull/2871#issuecomment-1341116696
+httpReadBufferSize: 8192


### PR DESCRIPTION
## Pull request description 

Set a sensible default for API server HTTP Read buffer size

Avoid explicit use of the following when using oauth2-proxy in front of api server

``` 
    testkube-api:
      extraEnvVars:
      - name: APISERVER_HTTP_READBUFFERSIZE
        value: "8192"
``` 

Relates to https://github.com/kubeshop/testkube/issues/2870

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally: **only tested extraEnvVars workaround so far**
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-