### PR TITLE
fix: convert the var to string

### DIFF
--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -167,11 +167,11 @@ spec:
               value: "testkube-api-server-config-{{ .Release.Namespace }}"
             {{- if .Values.httpBodyLimit }}
             - name: APISERVER_HTTP_BODY_LIMIT
-              value: {{ .Values.httpBodyLimit }}
+              value: {{ .Values.httpBodyLimit | quote }}
             {{- end}}
             {{- if .Values.httpReadBufferSize }}
             - name: APISERVER_HTTP_READBUFFERSIZE
-              value: {{ .Values.httpReadBufferSize }}
+              value: {{ .Values.httpReadBufferSize | quote }}
             {{- end}}
             - name: TESTKUBE_OAUTH_CLIENTID
               value:  "{{ .Values.cliIngress.oauth.clientID }}"


### PR DESCRIPTION
## Pull request description 
Added `quote` function to convert api vars from number to string, because the deployment failed with the error:
```
 json: cannot unmarshal number into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
```


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-