### PR TITLE
fix: testkube service monitor target port

### DIFF
--- a/charts/testkube-api/templates/servicemonitor.yaml
+++ b/charts/testkube-api/templates/servicemonitor.yaml
@@ -15,7 +15,7 @@ spec:
   {{- if .Values.prometheus.interval }}
   - interval: {{ .Values.prometheus.interval }}
   {{- end }}
-    targetPort: 8088
+    targetPort: {{ .Values.service.port }}
   selector:
     matchLabels:
       {{- include "testkube-api.selectorLabels" . | nindent 6 }}

--- a/charts/testkube-api/templates/servicemonitor.yaml
+++ b/charts/testkube-api/templates/servicemonitor.yaml
@@ -15,7 +15,7 @@ spec:
   {{- if .Values.prometheus.interval }}
   - interval: {{ .Values.prometheus.interval }}
   {{- end }}
-    port: http
+    targetPort: 8088
   selector:
     matchLabels:
       {{- include "testkube-api.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
## Pull request description 

Fix service monitor target port

api-server listens on locahost:8088/metrics but service monitor was scraping localhost:80/metrics

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

Before the fix
![image](https://github.com/kubeshop/helm-charts/assets/4748380/af358128-b909-492b-ba45-da4365266e6e)


After the fix
![image](https://github.com/kubeshop/helm-charts/assets/4748380/165822f6-3efe-4b4e-a488-de545e01308a)


-