### PR TITLE
feat: testkube/main: add cloud migrate environment variable

### DIFF
--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -197,6 +197,10 @@ spec:
             - name: TESTKUBE_CLOUD_ENV_ID
               value:  "{{ .Values.cloud.envId }}"
             {{- end}}
+            {{- if .Values.cloud.migrate }}
+            - name: TESTKUBE_CLOUD_MIGRATE
+              value:  "{{ .Values.cloud.migrate }}"
+            {{- end}}
             - name: TESTKUBE_WATCHER_NAMESPACES
               value: "{{ include "testkube-api.watcher-namespaces" . | nindent 12 | trim }}"
             {{- if .Values.extraEnvVars }}

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -61,6 +61,8 @@ cloud:
   orgId: ""
   ## Environment ID
   envId: ""
+  ## true if migration from OSS
+  migrate: ""
 
 ## Multinamespace feature. Disabled by default
 multinamespace:


### PR DESCRIPTION
## Pull request description 

Merging to main!

We need a way to pass for cloud whether the it's fresh installation or migration.

The plan is for testkube cli and helm upgrade to set this variable, otherwise for fresh installation we will not set it.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-