### PR TITLE
testkube-operator: Removed ns from tokenSecret and usernameSecret

### DIFF
--- a/charts/testkube-operator/templates/tests.testkube.io_tests.yaml
+++ b/charts/testkube-operator/templates/tests.testkube.io_tests.yaml
@@ -388,9 +388,6 @@ spec:
                             name:
                               description: object name
                               type: string
-                            namespace:
-                              description: object kubernetes namespace
-                              type: string
                           required:
                             - key
                             - name
@@ -414,9 +411,6 @@ spec:
                               type: string
                             name:
                               description: object name
-                              type: string
-                            namespace:
-                              description: object kubernetes namespace
                               type: string
                           required:
                             - key


### PR DESCRIPTION
## Pull request description 
Pods can't use secrets from a different namespace as env vars as explained in issue [#4308](https://github.com/kubeshop/testkube/issues/4038). This PR removes the namespace key from the CRD.
I am in doubt whether or not this is all that is required to remove it, so thoughts are welcomed about this.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes
Removed namespace from tokenSecret and usernameSecret from `tests.testkube.io_tests.yaml` CRD
-

## Fixes

-