### PR TITLE
charts: add warning for global image params

### DIFF
--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 ### @section  Global image parameters
+## Important! Please, note that this will override sub-chart image parameters.
 ## Global Docker image registry
 ## Global Docker registry secret names as an array
 global:

--- a/charts/testkube-dashboard/values.yaml
+++ b/charts/testkube-dashboard/values.yaml
@@ -2,7 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-#Global image parameters
+## Global image parameters
+## Important! Please, note that this will override sub-chart image parameters.
 ## @param global.imageRegistry Global Docker image registry
 ## @param global.imagePullSecrets [array] Global Docker registry secret names as an array
 ## @param global.labels Labels to add to all deployed objects

--- a/charts/testkube-operator/values.yaml
+++ b/charts/testkube-operator/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 ### @section  Global image parameters
+## Important! Please, note that this will override sub-chart image parameters.
 ## Global Docker image registry
 ## Global Docker registry secret names as an array
 ## Labels to add to all deployed objects

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 # -- Global image parameters
+# -- Important! Please, note that this will override sub-chart image parameters.
 global:
   # -- Global Docker image registry
   imageRegistry: ""


### PR DESCRIPTION
## Pull request description 
Added warning to helm charts that Global params will override sub-chart ones. 


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-