### PR TITLE
feat: update referencing of secrets in minio and TK API

### DIFF
--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -51,18 +51,50 @@ spec:
             {{- if .Values.mongodb.sslCertSecret }}
             - name: API_MONGO_SSL_CERT
               value: {{ .Values.mongodb.sslCertSecret }}
+              {{- else }}
+              {{- if .Values.mongodb.sslCertSecretSecretName }}
+            - name: API_MONGO_SSL_CERT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mongodb.sslCertSecretSecretName }}
+                  key: {{ .Values.mongodb.sslCertSecretSecretKey }}
+            {{- end }}
             {{- end }}
             {{- if .Values.mongodb.sslCAFileKey }}
             - name: API_MONGO_SSL_CA_FILE_KEY
               value: {{ .Values.mongodb.sslCAFileKey }}
+              {{- else }}
+              {{- if .Values.mongodb.sslCAFileKeySecretName }}
+            - name: API_MONGO_SSL_CA_FILE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mongodb.sslCAFileKeySecretName }}
+                  key: {{ .Values.mongodb.sslCAFileKeySecretKey }}
+              {{- end }}
             {{- end }}
             {{- if .Values.mongodb.sslClientFileKey }}
             - name: API_MONGO_SSL_CLIENT_FILE_KEY
               value: {{ .Values.mongodb.sslClientFileKey }}
+              {{- else }}
+            {{- if .Values.mongodb.sslClientFileKeySecretName }}
+            - name: API_MONGO_SSL_CLIENT_FILE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mongodb.sslClientFileKeySecretName }}
+                  key: {{ .Values.mongodb.sslClientFileKeySecretKey }}
+            {{- end }}
             {{- end }}
             {{- if .Values.mongodb.sslClientFilePassKey }}
             - name: API_MONGO_SSL_CLIENT_FILE_PASS_KEY
               value: {{ .Values.mongodb.sslClientFilePassKey }}
+              {{- else }}
+            {{- if .Values.mongodb.sslClientFilePassSecretName }}
+            - name: API_MONGO_SSL_CLIENT_FILE_PASS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mongodb.sslClientFilePassSecretName }}
+                  key: {{ .Values.mongodb.sslClientFilePassSecretKey }}
+              {{- end }}
             {{- end }}
             {{- if .Values.mongodb.dbType }}
             - name: API_MONGO_DB_TYPE
@@ -118,9 +150,23 @@ spec:
             - name: "STORAGE_EXPIRATION"
               value:  "{{ .Values.storage.expiration }}"
             - name: "STORAGE_ACCESSKEYID"
+              {{- if .Values.storage.accessKeyId }}
               value:  "{{ .Values.storage.accessKeyId }}"
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.storage.secretNameAccessKeyId }}
+                  key: {{ .Values.storage.secretKeyAccessKeyId }}
+            {{- end }}
             - name: "STORAGE_SECRETACCESSKEY"
+              {{- if .Values.storage.accessKey }}
               value: "{{ .Values.storage.accessKey }}"
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.storage.secretNameAccessKey }}
+                  key: {{ .Values.storage.secretKeyAccessKey }}
+            {{- end }}
             - name: "STORAGE_REGION"
               value: "{{ .Values.storage.region }}"
             - name: "STORAGE_TOKEN"

--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -88,12 +88,12 @@ spec:
             - name: API_MONGO_SSL_CLIENT_FILE_PASS_KEY
               value: {{ .Values.mongodb.sslClientFilePassKey }}
               {{- else }}
-            {{- if .Values.mongodb.sslClientFilePassSecretName }}
+            {{- if .Values.mongodb.sslClientFilePassKeySecretName }}
             - name: API_MONGO_SSL_CLIENT_FILE_PASS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.mongodb.sslClientFilePassSecretName }}
-                  key: {{ .Values.mongodb.sslClientFilePassSecretKey }}
+                  name: {{ .Values.mongodb.sslClientFilePassKeySecretName }}
+                  key: {{ .Values.mongodb.sslClientFilePassKeySecretKey }}
               {{- end }}
             {{- end }}
             {{- if .Values.mongodb.dbType }}
@@ -164,8 +164,8 @@ spec:
               {{- else }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.storage.secretNameAccessKey }}
-                  key: {{ .Values.storage.secretKeyAccessKey }}
+                  name: {{ .Values.storage.secretNameSecretAccessKey }}
+                  key: {{ .Values.storage.secretKeySecretAccessKey }}
             {{- end }}
             - name: "STORAGE_REGION"
               value: "{{ .Values.storage.region }}"

--- a/charts/testkube-api/templates/minio.yaml
+++ b/charts/testkube-api/templates/minio.yaml
@@ -57,6 +57,9 @@ spec:
           persistentVolumeClaim:
             # Name of the PVC created earlier
             claimName: testkube-minio-pv-claim-{{ .Release.Namespace }}
+        {{- if .Values.minio.extraVolumes }}
+        {{- include "global.tplvalues.render" (dict "value" .Values.minio.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
       containers:
         - name: testkube-minio
           # Volume mounts for this container
@@ -64,6 +67,9 @@ spec:
             # Volume 'data' is mounted to path '/data'
             - name: data
               mountPath: "/data"
+            {{- if .Values.minio.extraVolumeMounts }}
+            {{- include "global.tplvalues.render" (dict "value" .Values.minio.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
           # Pulls the lastest Minio image from Docker Hub
           image: {{ include "global.images.image" (dict "imageRoot" .Values.minio.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.minio.image.pullPolicy }}
@@ -75,9 +81,23 @@ spec:
           env:
             # MinIO access key and secret key
             - name: MINIO_ROOT_USER
+              {{- if .Values.minio.minioRootUser }}
               value: {{ .Values.minio.minioRootUser }}
+            {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.minio.secretUserName }}
+                  key: {{ .Values.minio.secretUserKey }}
+            {{- end }}
             - name: MINIO_ROOT_PASSWORD
+              {{- if .Values.minio.minioRootPassword }}
               value: {{ .Values.minio.minioRootPassword }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.minio.secretPasswordName }}
+                  key: {{ .Values.minio.secretPasswordKey }}
+            {{- end }}
             - name: CONSOLE_PORT
               value: "9090"
             - name: CONSOLE_TLS_PORT
@@ -141,7 +161,7 @@ metadata:
   labels:
     {{- if .Values.global.labels }}
     {{- include "global.tplvalues.render" ( dict "value" .Values.global.labels "context" $ ) | nindent 4 }}
-    {{- end }}  
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -162,12 +162,16 @@ affinity: {}
 storage:
   endpoint: ""
   endpoint_port: "9000"
-  accessKeyId: "minio"
-  accessKey: "minio123"
+  accessKeyId: ""
+  accessKey: ""
   ## k8s Secret name for storage accessKeyId
   secretNameAccessKeyId: ""
   ## Key for storage accessKeyId taken from k8s secret
   secretKeyAccessKeyId: ""
+  ## K8s Secret Name for storage secretAccessKeyId
+  secretNameSecretAccessKey: ""
+  ## Key for storage secretAccessKeyId taken from k8s secret
+  secretKeySecretAccessKey: ""
   region: ""
   token: ""
   bucket: "testkube-artifacts"
@@ -219,11 +223,13 @@ mongodb:
   ## or use dsn in secrets
   # secretName: testkube-secrets
   # secretKey: mongo-dsn
+
   ## SSL certificate secret reference
   # sslCertSecret: mongo-ssl-certs
   # sslCAFileKey: sslCertificateAuthorityFile
   # sslClientFileKey: sslClientCertificateKeyFile
   # sslClientFilePassKey: sslClientCertificateKeyFilePassword
+
   ## k8s Secret Name for SSL Client Certificate Key File Password
   ## Key for SSL Client Certificate Key File Password k8s Secret
   ## k8s Secret Name for SSL Client Certificate Key File
@@ -232,14 +238,15 @@ mongodb:
   ## Key for SSL CA File Key k8s Secret
   ## k8s Secret Name for SSL Cert Secret
   ## Key for SSL Cert Secret k8s Secret
-  # sslClientFilePassSecretName: sslClientFilePassSecretName
-  # sslClientFilePassSecretKey: sslClientFilePassSecretKey
+  # sslClientFilePassKeySecretName: sslClientFilePassKeySecretName
+  # sslClientFilePassKeySecretKey: sslClientFilePassKeySecretKey
   # sslClientFileKeySecretName: sslClientFileKeySecretName
   # sslClientFileKeySecretKey: sslClientFileKeySecretKey
   # sslCAFileKeySecretName: sslCAFileKeySecretName
   # sslCAFileKeySecretKey: sslCAFileKeySecretKey
   # sslCertSecretSecretName: sslCertSecretSecretName
   # sslCertSecretSecretKey: sslCertSecretSecretKey
+
   allowDiskUse: true
   # to use docdb with TLS, set dbType to docdb and allowTLS to true
   # dbType possible values: docdb|mongo; empty string defaults to mongo

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -164,6 +164,10 @@ storage:
   endpoint_port: "9000"
   accessKeyId: "minio"
   accessKey: "minio123"
+  ## k8s Secret name for storage accessKeyId
+  secretNameAccessKeyId: ""
+  ## Key for storage accessKeyId taken from k8s secret
+  secretKeyAccessKeyId: ""
   region: ""
   token: ""
   bucket: "testkube-artifacts"
@@ -220,6 +224,22 @@ mongodb:
   # sslCAFileKey: sslCertificateAuthorityFile
   # sslClientFileKey: sslClientCertificateKeyFile
   # sslClientFilePassKey: sslClientCertificateKeyFilePassword
+  ## k8s Secret Name for SSL Client Certificate Key File Password
+  ## Key for SSL Client Certificate Key File Password k8s Secret
+  ## k8s Secret Name for SSL Client Certificate Key File
+  ## Key for SSL Client Certificate Key File k8s Secret
+  ## k8s Secret Name for SSL CA File Key
+  ## Key for SSL CA File Key k8s Secret
+  ## k8s Secret Name for SSL Cert Secret
+  ## Key for SSL Cert Secret k8s Secret
+  # sslClientFilePassSecretName: sslClientFilePassSecretName
+  # sslClientFilePassSecretKey: sslClientFilePassSecretKey
+  # sslClientFileKeySecretName: sslClientFileKeySecretName
+  # sslClientFileKeySecretKey: sslClientFileKeySecretKey
+  # sslCAFileKeySecretName: sslCAFileKeySecretName
+  # sslCAFileKeySecretKey: sslCAFileKeySecretKey
+  # sslCertSecretSecretName: sslCertSecretSecretName
+  # sslCertSecretSecretKey: sslCertSecretSecretKey
   allowDiskUse: true
   # to use docdb with TLS, set dbType to docdb and allowTLS to true
   # dbType possible values: docdb|mongo; empty string defaults to mongo
@@ -263,8 +283,20 @@ minio:
     pullPolicy: IfNotPresent
   ## ServiceAccount name to use for Minio
   serviceAccountName: ""
-  ## Root username
-  ## Root password
+  ## Optionally specify extra list of additional volumeMounts for Minio
+  extraVolumeMounts: []
+  ## Optionally specify extra list of additional volumes for Minio
+  extraVolumes: []
+  ## k8s Secret name for Minio root username
+  secretUserName: ""
+  ## Secret key for Minio root username taken from k8s secret
+  secretUserKey: ""
+  ## k8s Secret name for Minio root password
+  secretPasswordName: ""
+  ## Secret key for Minio root username taken from k8s secret
+  secretPasswordKey: ""
+  ## Plain text Minio root username
+  ## Plain text Minio root password
   minioRootUser: ""
   minioRootPassword: ""
   ## PVC Storage Request for MinIO. Should be available in the cluster.

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -288,7 +288,7 @@ testkube-api:
       repository: minio/minio
       tag: latest
     # -- ServiceAccount name to use for Minio
-    serviceAccountName: "minio-service-account"
+    serviceAccountName: ""
     extraVolumeMounts: []
     extraVolumes: []
     ## k8s Secret name for Minio root username
@@ -398,6 +398,14 @@ testkube-api:
     accessKeyId: "minio"
     # -- MinIO Secret Access Key
     accessKey: "minio123"
+    ## k8s Secret name for storage accessKeyId
+    secretNameAccessKeyId: ""
+    ## Key for storage accessKeyId taken from k8s secret
+    secretKeyAccessKeyId: ""
+    ## K8s Secret Name for storage secretAccessKeyId
+    secretNameSecretAccessKey: ""
+    ## Key for storage secretAccessKeyId taken from k8s secret
+    secretKeySecretAccessKey: ""
     # -- MinIO Region
     region: ""
     # -- MinIO Token
@@ -435,10 +443,10 @@ testkube-api:
 
     ## -- SSL certificate secret reference
     # -- k8s Secret Name for SSL Client Certificate Key File Password
-    # sslClientFilePassSecretName: sslClientFilePassSecretName
+    # sslClientFilePassKeySecretName: sslClientFilePassKeySecretName
 
     # -- Key for SSL Client Certificate Key File Password k8s Secret
-    # sslClientFilePassSecretKey: sslClientFilePassSecretKey
+    # sslClientFilePassKeySecretKey: sslClientFilePassKeySecretKey
 
     # -- k8s Secret Name for SSL Client Certificate Key File
     # sslClientFileKeySecretName: sslClientFileKeySecretName

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -288,7 +288,17 @@ testkube-api:
       repository: minio/minio
       tag: latest
     # -- ServiceAccount name to use for Minio
-    serviceAccountName: ""
+    serviceAccountName: "minio-service-account"
+    extraVolumeMounts: []
+    extraVolumes: []
+    ## k8s Secret name for Minio root username
+    secretUserName: ""
+    ## Secret key for Minio root username taken from k8s secret
+    secretUserKey: ""
+    ## k8s Secret name for Minio root password
+    secretPasswordName: ""
+    ## Secret key for Minio root username taken from k8s secret
+    secretPasswordKey: ""
     # -- Root username
     minioRootUser: "minio"
     # -- Root password
@@ -422,6 +432,32 @@ testkube-api:
     # secretKey: mongo-dsn
     # -- Allow or prohibit writing temporary files on disk when a pipeline stage exceeds the 100 megabyte limit.
     allowDiskUse: true
+
+    ## -- SSL certificate secret reference
+    # -- k8s Secret Name for SSL Client Certificate Key File Password
+    # sslClientFilePassSecretName: sslClientFilePassSecretName
+
+    # -- Key for SSL Client Certificate Key File Password k8s Secret
+    # sslClientFilePassSecretKey: sslClientFilePassSecretKey
+
+    # -- k8s Secret Name for SSL Client Certificate Key File
+    # sslClientFileKeySecretName: sslClientFileKeySecretName
+
+    # -- Key for SSL Client Certificate Key File k8s Secret
+    # sslClientFileKeySecretKey: sslClientFileKeySecretKey
+
+    # -- k8s Secret Name for SSL CA File Key
+    # sslCAFileKeySecretName: sslCAFileKeySecretName
+
+    # -- Key for SSL CA File Key k8s Secret
+    # sslCAFileKeySecretKey: sslCAFileKeySecretKey
+
+
+    # -- k8s Secret Name for SSL Cert Secret
+    # sslCertSecretSecretName: sslCertSecretSecretName
+
+    # -- Key for SSL Cert Secret k8s Secret
+    # sslCertSecretSecretKey: sslCertSecretSecretKey
 
   # -- Testkube API Liveness probe parameters
   livenessProbe:


### PR DESCRIPTION
## Pull request description 
Added an option to retrieve Minio credentials and Mongo SSL certificate data from k8s secrets. 


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-