### PR TITLE
fix: resource separation inside conditional loops to avoid templating issue when operator webhook disabled

### DIFF
--- a/charts/testkube-operator/templates/pre-upgrade-sa.yaml
+++ b/charts/testkube-operator/templates/pre-upgrade-sa.yaml
@@ -10,8 +10,8 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 {{- end }}
 
----
 {{- if .Values.preUpgrade.serviceAccount.create }}
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -26,8 +26,8 @@ rules:
     verbs: ["create","delete","get","list","patch","update","watch"]
 {{- end }}
 
----
 {{- if .Values.preUpgrade.serviceAccount.create }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/testkube-operator/templates/role.yaml
+++ b/charts/testkube-operator/templates/role.yaml
@@ -321,9 +321,8 @@ rules:
   - watch
   - deletecollection
 
----
-
 {{- if and .Values.webhook.enabled .Values.webhook.patch.enabled }}
+---
 apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:

--- a/charts/testkube-operator/templates/rolebinding.yaml
+++ b/charts/testkube-operator/templates/rolebinding.yaml
@@ -91,9 +91,8 @@ subjects:
   name: {{ include "testkube-operator.serviceAccountName" . }}
   namespace: {{ include "testkube-operator.namespace" . }}
 
----
-
 {{- if and .Values.webhook.enabled .Values.webhook.patch.enabled }}
+---
 apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
@@ -121,5 +120,4 @@ subjects:
     name: {{ include "testkube-operator.webhook.serviceAccountName" . }}
     namespace: {{ include "testkube-operator.namespace" . }}
 {{- end }}
-  {{- end -}}
-
+{{- end -}}

--- a/charts/testkube-operator/templates/serviceaccount.yaml
+++ b/charts/testkube-operator/templates/serviceaccount.yaml
@@ -17,9 +17,9 @@ metadata:
   {{- include "global.tplvalues.render" ( dict "value" .Values.global.annotations "context" $ ) | nindent 4 }}
   {{- end }}
 {{- end }}
----
 
 {{- if and .Values.webhook.enabled .Values.webhook.patch.enabled }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -41,4 +41,4 @@ metadata:
     {{- if .Values.global.annotations }}
     {{- include "global.tplvalues.render" ( dict "value" .Values.global.annotations "context" $ ) | nindent 4 }}
     {{- end }}
-    {{- end }}
+{{- end }}

--- a/charts/testkube/templates/pre-upgrade-sa.yaml
+++ b/charts/testkube/templates/pre-upgrade-sa.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-weight": "4"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
-  {{- end }}
+{{- end }}
 
----
 {{- if .Values.preUpgradeHook.serviceAccount.create }}
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -29,8 +29,8 @@ rules:
     verbs: ["create","delete","get","list","patch","update","watch"]
 {{- end }}
 
----
 {{- if .Values.preUpgradeHook.serviceAccount.create }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:


### PR DESCRIPTION
## Pull request description 

Fix the resource separator character to be inside the conditional loops to avoid adding extra separators when the webhook/preUpgrade section is disabled, which creates issues with the templating.

See discussion on issue  #563 

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

- No

## Changes

-

## Fixes

- testkube-operator issues with role,rolebinding,ServiceAccount resource separtation when webhook/PreUpgrade is disabled.