### PR TITLE
fix: revert logic for secrets in minio

### DIFF
--- a/charts/testkube-api/templates/minio.yaml
+++ b/charts/testkube-api/templates/minio.yaml
@@ -81,23 +81,23 @@ spec:
           env:
             # MinIO access key and secret key
             - name: MINIO_ROOT_USER
-              {{- if .Values.minio.minioRootUser }}
-              value: {{ .Values.minio.minioRootUser }}
-            {{- else }}
+              {{- if .Values.minio.secretUserName }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.minio.secretUserName }}
                   key: {{ .Values.minio.secretUserKey }}
-            {{- end }}
-            - name: MINIO_ROOT_PASSWORD
-              {{- if .Values.minio.minioRootPassword }}
-              value: {{ .Values.minio.minioRootPassword }}
               {{- else }}
+              value: {{ .Values.minio.minioRootUser }}
+              {{- end }}
+            - name: MINIO_ROOT_PASSWORD
+              {{- if .Values.minio.secretPasswordName }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.minio.secretPasswordName }}
                   key: {{ .Values.minio.secretPasswordKey }}
-            {{- end }}
+              {{- else }}
+              value: {{ .Values.minio.minioRootPassword }}
+              {{- end }}
             - name: CONSOLE_PORT
               value: "9090"
             - name: CONSOLE_TLS_PORT


### PR DESCRIPTION
## Pull request description 
Revert logic for passing secrets for minio, since it breaks feature https://github.com/kubeshop/testkube/issues/3965
 

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-