### PR TITLE
fix(chart/tracetest): update probes configuration on Tracetest to consider pathPrefix config

### DIFF
--- a/charts/tracetest/templates/_helpers.tpl
+++ b/charts/tracetest/templates/_helpers.tpl
@@ -90,3 +90,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define a valid pathPrefix
+*/}}
+{{- define "tracetest.pathPrefix" -}}
+    {{- if .Values.server.pathPrefix }}
+        {{- .Values.server.pathPrefix }}
+    {{- else }}
+        {{- "/" }}
+    {{- end }}
+{{- end }}

--- a/charts/tracetest/templates/deployment.yaml
+++ b/charts/tracetest/templates/deployment.yaml
@@ -53,11 +53,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: {{ include "tracetest.pathPrefix" . }}
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: {{ include "tracetest.pathPrefix" . }}
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/tracetest/values.yaml
+++ b/charts/tracetest/values.yaml
@@ -111,6 +111,7 @@ server:
   httpPort: 11633
   otlpGrpcPort: 4317
   otlpHttpPort: 4318
+
   # Indicates which telemetry components will be used by Tracetest
   telemetry:
     # The exporter that tracetest will use to send telemetry


### PR DESCRIPTION
## Pull request description 

On this PR, we detect if the user defines the variable `server.pathPrefix` on the helm chart and update the livenessProbe and readinessProbe to consider it.

Loom: https://www.loom.com/share/110b45511ece468191b5be61bb79ee91?sid=af66b2a9-c819-451e-a956-313683ad013c

## Checklist (choose whats happened)

- [x] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Changes

- Changed tracetest deployment.yaml to consider pathPrefix variable on probes