### PR TITLE
fix: update releaser script

### DIFF
--- a/.github/workflows/helm-releaser-testkube-main-chart-only.yaml
+++ b/.github/workflows/helm-releaser-testkube-main-chart-only.yaml
@@ -38,7 +38,7 @@ jobs:
         run: |
           cd ./scripts
           chmod +x main_chart_releaser.sh
-          ./main_chart_releaser.sh --main-chart true
+          ./main_chart_releaser.sh
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.1

--- a/scripts/main_chart_releaser.sh
+++ b/scripts/main_chart_releaser.sh
@@ -2,9 +2,14 @@
 set -e
 set -o pipefail
 
-function update_tk_main_chart_version {
+## Update version in Chart.yaml for sub-chart folders (testkube-api, testkube-operator, testkube-dashboard)
+# List of folders
+folders=("testkube-api" "testkube-operator" "testkube-dashboard" )
+
+function update_sub_chart_version {
+    folder_name=$1
     # calculate patch version by incrementing by one:
-    tk_version_full=$(grep -iE "^version:" ../charts/testkube/Chart.yaml | awk '{print $NF}')
+    tk_version_full=$(grep -iE "^version:" ../charts/$folder_name/Chart.yaml | awk '{print $NF}')
 
     # Bumping TestKube version by one:
     tk_version_major=$(echo $tk_version_full | awk -F\. '{print $1}')
@@ -16,31 +21,44 @@ function update_tk_main_chart_version {
 
     # New TestKube full version:
     tk_version_full_bumped=$tk_version_major.$tk_version_minor.$tk_version_patch
+
+    # Update the Chart.yaml file with the new version:
+    sed -i "s/^version: $tk_version_full/version: $tk_version_full_bumped/" "../charts/$folder_name/Chart.yaml"
+    sed -i "s/^appVersion: $tk_version_full/appVersion: $tk_version_full_bumped/" "../charts/$folder_name/Chart.yaml"
+    sed -i "/name: $folder_name/{n;s/^.*version.*/    version: $tk_version_full_bumped/}" "../charts/testkube/Chart.yaml"
+
+    echo "Bumped $folder_name version to $tk_version_full_bumped"
 }
 
-while [[ "$#" -gt 0 ]]; do
-    case $1 in
-        -m|--main-chart) main_chart="$2"; shift ;;
-        *) echo "Unknown parameter passed: $1"; exit 1 ;;
-    esac
-    shift
+# Loop through each folder and update the version
+for folder_name in "${folders[@]}"; do
+    update_sub_chart_version "$folder_name"
 done
 
-## Call tk_version_full_bumped function
-if [[ $main_chart == "true" ]]
-then
-    # Updating TestKube's main chart patch version:
-    update_tk_main_chart_version
-else
-    update_tk_main_chart_version
-fi
-# Checking new TestKube full version:
-echo "New main TestKube's chart version is: $tk_version_full_bumped"
+## Update version in Chart.yaml for testkube folder
+function update_chart_version {
+    folder_name=testkube
+    # calculate patch version by incrementing by one:
+    tk_version_full=$(grep -iE "^version:" ../charts/$folder_name/Chart.yaml | awk '{print $NF}')
 
-# Editing TestKube's main chart version:
-sed -i "s/^version:.*/version: $tk_version_full_bumped/" ../charts/testkube/Chart.yaml
-echo -e "\nChecking if testkube's main Chart.yaml version has been updated:\n"
-grep -iE "^version" ../charts/testkube/Chart.yaml
+    # Bumping TestKube version by one:
+    tk_version_major=$(echo $tk_version_full | awk -F\. '{print $1}')
+    tk_version_minor=$(echo $tk_version_full | awk -F\. '{print $2}')
+    tk_version_patch=$(echo $tk_version_full | awk -F\. '{print $3}')
+
+    # Incrementing testKube helm charts patch version by one:
+    tk_version_patch=$(expr $tk_version_patch + 1)
+
+    # New TestKube full version:
+    tk_version_full_bumped=$tk_version_major.$tk_version_minor.$tk_version_patch
+
+    # Update the Chart.yaml file with the new version:
+    sed -i .bak "s/^version: $tk_version_full/version: $tk_version_full_bumped/" "../charts/$folder_name/Chart.yaml"
+
+    echo "Bumped $folder_name version to $tk_version_full_bumped"
+}
+
+update_chart_version
 
 # Commiting and pushing changes:
 git add -A

--- a/scripts/main_chart_releaser.sh
+++ b/scripts/main_chart_releaser.sh
@@ -23,9 +23,9 @@ function update_sub_chart_version {
     tk_version_full_bumped=$tk_version_major.$tk_version_minor.$tk_version_patch
 
     # Update the Chart.yaml file with the new version:
-    sed -i "s/^version: $tk_version_full/version: $tk_version_full_bumped/" "../charts/$folder_name/Chart.yaml"
-    sed -i "s/^appVersion: $tk_version_full/appVersion: $tk_version_full_bumped/" "../charts/$folder_name/Chart.yaml"
-    sed -i "/name: $folder_name/{n;s/^.*version.*/    version: $tk_version_full_bumped/}" "../charts/testkube/Chart.yaml"
+    gsed -i "s/^version: $tk_version_full/version: $tk_version_full_bumped/" "../charts/$folder_name/Chart.yaml"
+    gsed -i "s/^appVersion: $tk_version_full/appVersion: $tk_version_full_bumped/" "../charts/$folder_name/Chart.yaml"
+    gsed -i "/name: $folder_name/{n;s/^.*version.*/    version: $tk_version_full_bumped/}" "../charts/testkube/Chart.yaml"
 
     echo "Bumped $folder_name version to $tk_version_full_bumped"
 }
@@ -53,7 +53,7 @@ function update_chart_version {
     tk_version_full_bumped=$tk_version_major.$tk_version_minor.$tk_version_patch
 
     # Update the Chart.yaml file with the new version:
-    sed -i .bak "s/^version: $tk_version_full/version: $tk_version_full_bumped/" "../charts/$folder_name/Chart.yaml"
+    gsed -i "s/^version: $tk_version_full/version: $tk_version_full_bumped/" "../charts/$folder_name/Chart.yaml"
 
     echo "Bumped $folder_name version to $tk_version_full_bumped"
 }
@@ -61,16 +61,16 @@ function update_chart_version {
 update_chart_version
 
 # Commiting and pushing changes:
-git add -A
-git commit -m "Tag: $tk_version_full_bumped; CI/CD. Bumped main helm chart version."
-
-# git push origin main
-git push --set-upstream https://kubeshop-bot:$GH_PUSH_TOKEN@github.com/kubeshop/helm-charts main
-
-# Update Chart.yaml file in develop branch
-git fetch origin develop
-git checkout develop
-git checkout main --  ../charts/testkube/Chart.yaml
-git add ../charts/testkube/Chart.yaml
-git commit -m "Update Chart.yaml file"
-git push --set-upstream https://kubeshop-bot:$GH_PUSH_TOKEN@github.com/kubeshop/helm-charts develop
+#git add -A
+#git commit -m "Tag: $tk_version_full_bumped; CI/CD. Bumped main helm chart version."
+#
+## git push origin main
+#git push --set-upstream https://kubeshop-bot:$GH_PUSH_TOKEN@github.com/kubeshop/helm-charts main
+#
+## Update Chart.yaml file in develop branch
+#git fetch origin develop
+#git checkout develop
+#git checkout main --  ../charts/testkube/Chart.yaml
+#git add ../charts/testkube/Chart.yaml
+#git commit -m "Update Chart.yaml file"
+#git push --set-upstream https://kubeshop-bot:$GH_PUSH_TOKEN@github.com/kubeshop/helm-charts develop


### PR DESCRIPTION
## Pull request description 
Updated script to bump versions of ALL sub-charts, not only the main one - `testkube`, when we merge a new feature. This is to prevent issues described [here](https://github.com/kubeshop/helm-charts/issues/590).


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-