### PR TITLE
Allow to specify nodeSelector for preUpgradeHook

### DIFF
--- a/charts/testkube/templates/pre-upgrade.yaml
+++ b/charts/testkube/templates/pre-upgrade.yaml
@@ -54,4 +54,7 @@ spec:
       {{- if .Values.preUpgradeHook.tolerations }}
       tolerations: {{ toYaml .Values.preUpgradeHook.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.preUpgradeHook.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.preUpgradeHook.nodeSelector | nindent 8 }}
+      {{- end }}
   {{- end }}

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -33,6 +33,8 @@ preUpgradeHook:
   # -- Create SA for upgrade hook
   serviceAccount:
     create: true
+  # -- Node labels for pod assignment.
+  nodeSelector: {}
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   # -- MongoDB Upgrade Pod Security Context
   podSecurityContext: {}


### PR DESCRIPTION
## Pull request description 

This change add possbility to pass nodeSelector for a preUpgradeHook.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [*] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


## Changes

- pass nodeSelector for preUpgradeHook