### PR TITLE
feat: Allow extension of oauth2-proxy environment variables with envFrom

### DIFF
--- a/charts/testkube-dashboard/templates/oauth2-deployment.yaml
+++ b/charts/testkube-dashboard/templates/oauth2-deployment.yaml
@@ -46,7 +46,7 @@ spec:
         {{- if .Values.oauth2.args }}
         {{- range .Values.oauth2.args }}
         - {{ . }}
-        {{- end }}  
+        {{- end }}
         {{- else }}
         - --provider=github
         - --email-domain=*
@@ -56,51 +56,69 @@ spec:
         # Register a new application
         # https://github.com/settings/applications/new
         env:
+        {{- with .Values.oauth2.env }}
+        {{- if or .clientId .secretClientIdName }}
         - name: OAUTH2_PROXY_CLIENT_ID
-          {{- if .Values.oauth2.env.secretClientIdName }}
+          {{- if .secretClientIdName }}
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.oauth2.env.secretClientIdName }}
-              key: {{ .Values.oauth2.env.secretClientIdKey }}
+              name: {{ .secretClientIdName }}
+              key: {{ .secretClientIdKey }}
           {{- else }}
-          value: "{{ .Values.oauth2.env.clientId }}"
+          value: "{{ .clientId }}"
           {{- end }}
+        {{- end }}
+        {{- if or .clientSecret .secretClientSecretName }}
         - name: OAUTH2_PROXY_CLIENT_SECRET
-          {{- if .Values.oauth2.env.secretClientSecretName }}
+          {{- if .secretClientSecretName }}
           valueFrom:
             secretKeyRef:
               name: {{ .Values.oauth2.env.secretClientSecretName }}
               key: {{ .Values.oauth2.env.secretClientSecretKey }}
           {{- else }}
-          value: "{{ .Values.oauth2.env.clientSecret }}"
+          value: "{{ .clientSecret }}"
           {{- end }}
+        {{- end }}
+        {{- if or .githubOrg .secretGithubOrgName }}
         - name: OAUTH2_PROXY_GITHUB_ORG
-          {{- if .Values.oauth2.env.secretGithubOrgName }}
+          {{- if .secretGithubOrgName }}
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.oauth2.env.secretGithubOrgName }}
-              key: {{ .Values.oauth2.env.secretGithubOrgKey }}
+              name: {{ .secretGithubOrgName }}
+              key: {{ .secretGithubOrgKey }}
           {{- else }}
-          value: "{{ .Values.oauth2.env.githubOrg }}"
+          value: "{{ .githubOrg }}"
           {{- end }}
+        {{- end }}
+        {{- if or .cookieSecret .secretCookieSecretName }}
         # docker run -ti --rm python:3-alpine python -c 'import secrets,base64; print(base64.b64encode(base64.b64encode(secrets.token_bytes(16))));'
         - name: OAUTH2_PROXY_COOKIE_SECRET
-          {{- if .Values.oauth2.env.secretCookieSecretName }}
+          {{- if .secretCookieSecretName }}
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.oauth2.env.secretCookieSecretName }}
-              key: {{ .Values.oauth2.env.secretCookieSecretKey }}
+              name: {{ .secretCookieSecretName }}
+              key: {{ .secretCookieSecretKey }}
           {{- else }}
-          value: "{{ .Values.oauth2.env.cookieSecret }}"
+          value: "{{ .cookieSecret }}"
           {{- end }}
+        {{- end }}
+        {{- with .cookieSecure }}
+        - name: OAUTH2_PROXY_COOKIE_SECURE
+          value: "{{ . }}"
+        {{- end }}
+        {{- with .redirectUrl }}
+        - name: OAUTH2_PROXY_REDIRECT_URL
+          value: "{{ . }}"
+        {{- end }}
+        {{- end }}{{/* with .Values.oauth2.env */}}
         - name: OAUTH2_PROXY_HTTP_ADDRESS
           value: "0.0.0.0:{{ .Values.oauth2.port }}"
-        - name: OAUTH2_PROXY_COOKIE_SECURE
-          value: "{{ .Values.oauth2.env.cookieSecure }}"
-        - name: OAUTH2_PROXY_REDIRECT_URL  
-          value: "{{ .Values.oauth2.env.redirectUrl }}"
         {{- if .Values.oauth2.extraEnvVars }}
         {{ include "global.tplvalues.render" (dict "value" .Values.oauth2.extraEnvVars "context" $) | nindent 8 | trim }}
+        {{- end }}
+        {{- if .Values.oauth2.extraEnvFrom }}
+        envFrom:
+        {{ include "global.tplvalues.render" (dict "value" .Values.oauth2.extraEnvFrom "context" $) | nindent 8 | trim }}
         {{- end }}
         image: {{ include "global.images.image" (dict "imageRoot" .Values.oauth2.image "global" .Values.global) }}
         imagePullPolicy: {{ .Values.oauth2.image.pullPolicy }}

--- a/charts/testkube-dashboard/templates/oauth2-deployment.yaml
+++ b/charts/testkube-dashboard/templates/oauth2-deployment.yaml
@@ -73,8 +73,8 @@ spec:
           {{- if .secretClientSecretName }}
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.oauth2.env.secretClientSecretName }}
-              key: {{ .Values.oauth2.env.secretClientSecretKey }}
+              name: {{ .secretClientSecretName }}
+              key: {{ .secretClientSecretKey }}
           {{- else }}
           value: "{{ .clientSecret }}"
           {{- end }}

--- a/charts/testkube-dashboard/values.yaml
+++ b/charts/testkube-dashboard/values.yaml
@@ -151,6 +151,13 @@ oauth2:
     #- --show-debug-on-error=true
   ## Array with extra environment variables
   extraEnvVars: []
+  ## Array with extra sources for environment variables
+  extraEnvFrom: []
+    #- configMapRef:
+    #    name: my-configmap-name
+    #- secretRef:
+    #    name: my-secret-name
+
   ## Oauth2 pod annotations
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   podAnnotations: {}

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -663,6 +663,8 @@ testkube-dashboard:
       #- --show-debug-on-error=true
     # -- Array with extra environment variables to add to Locator nodes
     extraEnvVars: []
+    ## Array with extra sources for environment variables
+    extraEnvFrom: []
     # ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
     # -- Oauth2 pod annotations
     podAnnotations: {}

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -663,8 +663,12 @@ testkube-dashboard:
       #- --show-debug-on-error=true
     # -- Array with extra environment variables to add to Locator nodes
     extraEnvVars: []
-    ## Array with extra sources for environment variables
+    # -- Array with extra sources for environment variables
     extraEnvFrom: []
+      #- configMapRef:
+      #    name: my-configmap-name
+      #- secretRef:
+      #    name: my-secret-name
     # ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
     # -- Oauth2 pod annotations
     podAnnotations: {}

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -655,8 +655,7 @@ testkube-dashboard:
     # -- Add additional labels to the pod (evaluated as a template)
     podLabels: {}
     # -- Array of args for oauth2 provider or github as default
-    args:
-      []
+    args: []
       #- --provider=github
       #- --email-domain=*
       #- --upstream=file:///dev/null


### PR DESCRIPTION
## Pull request description 

Allow reference of Secret or ConfigMap to provide multiple environment variables. This allows deployers of the Helm Chart to manage multiple sensitive or non-sensitive values without needing to override or modify multiple default values.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

- None

## Changes

- Allow extension of oauth2-proxy deployment with prexisting Secret or Configmap

## Fixes

- #611