### PR TITLE
fix: Allow override of REACT_APP_ROOT_ROUTE with proxyPrefix

### DIFF
--- a/charts/testkube-dashboard/templates/deployment.yaml
+++ b/charts/testkube-dashboard/templates/deployment.yaml
@@ -44,7 +44,11 @@ spec:
           - name: REACT_APP_API_SERVER_ENDPOINT
             value: "{{ .Values.apiServerEndpoint }}"
           - name: REACT_APP_ROOT_ROUTE
+            {{- if .Values.proxyPrefix }}
+            value: "{{ .Values.proxyPrefix }}"
+            {{- else }}
             value: "{{ .Values.ingress.path }}"
+            {{- end }}
           - name: REACT_APP_DISABLE_TELEMETRY
             value: "{{ .Values.disableTelemetry }}"
           - name: REACT_APP_CRD_OPERATOR_REVISION

--- a/charts/testkube-dashboard/values.yaml
+++ b/charts/testkube-dashboard/values.yaml
@@ -124,6 +124,11 @@ ingress:
     #     - testkube.example.com
     #   secretName: testkube-cert-secret
 
+## Proxy prefix to use when deploying
+## to a subpath and ingress.path contains a regex
+## Sets the env variable REACT_APP_ROOT_ROUTE
+proxyPrefix: ""
+
 ## Oauth parameters
 oauth2:
   ## Use oauth

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -561,6 +561,11 @@ testkube-dashboard:
   # -- Extra labels for Testkube Dashboard pods
   podLabels: {}
 
+  ## Proxy prefix to use when deploying
+  ## to a subpath and ingress.path contains a regex
+  ## Sets the env variable REACT_APP_ROOT_ROUTE
+  proxyPrefix: ""
+
   # -- Number of Testkube Dashboard Pod replicas
   replicaCount: 1
 


### PR DESCRIPTION
## Pull request description 

Allow user-specified value to override `REACT_APP_ROOT_ROUTE` reliably

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

- Use user-provided value for `REACT_APP_ROOT_ROUTE` when provided in `.Values.proxyPrefix` (this name was chosen in line with the oauth2-proxy argument name).  Fallback to using `.Values.ingress.path`

## Fixes

- #613