### PR TITLE
Add ability to set pod annotations on mongo upgrade job

### DIFF
--- a/charts/testkube/templates/pre-upgrade.yaml
+++ b/charts/testkube/templates/pre-upgrade.yaml
@@ -36,13 +36,15 @@ spec:
         {{- if .Values.preUpgradeHook.labels }}
         {{- include "global.tplvalues.render" ( dict "value" .Values.preUpgradeHook.labels "context" $ ) | nindent 8 }}
         {{- end }}
+      {{- if or .Values.global.annotations .Values.preUpgradeHook.podAnnotations }}
       annotations:
         {{- if .Values.global.annotations}}
-        {{- include "global.tplvalues.render" ( dict "value" .Values.global.annotations "context" $ ) | nindent 4 }}
+        {{- include "global.tplvalues.render" ( dict "value" .Values.global.annotations "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if .Values.preUpgradeHook.podAnnotations }}
-        {{- include "global.tplvalues.render" ( dict "value" .Values.preUpgradeHook.podAnnotations "context" $ ) | nindent 4 }}
+        {{- include "global.tplvalues.render" ( dict "value" .Values.preUpgradeHook.podAnnotations "context" $ ) | nindent 8 }}
         {{- end }}
+      {{- end }}
     spec:
       serviceAccountName: "{{ .Values.preUpgradeHook.name }}"
       {{- include "global.images.renderPullSecrets" . | nindent 6 }}

--- a/charts/testkube/templates/pre-upgrade.yaml
+++ b/charts/testkube/templates/pre-upgrade.yaml
@@ -36,6 +36,13 @@ spec:
         {{- if .Values.preUpgradeHook.labels }}
         {{- include "global.tplvalues.render" ( dict "value" .Values.preUpgradeHook.labels "context" $ ) | nindent 8 }}
         {{- end }}
+      annotations:
+        {{- if .Values.global.annotations}}
+        {{- include "global.tplvalues.render" ( dict "value" .Values.global.annotations "context" $ ) | nindent 4 }}
+        {{- end }}
+        {{- if .Values.preUpgradeHook.podAnnotations }}
+        {{- include "global.tplvalues.render" ( dict "value" .Values.preUpgradeHook.podAnnotations "context" $ ) | nindent 4 }}
+        {{- end }}
     spec:
       serviceAccountName: "{{ .Values.preUpgradeHook.name }}"
       {{- include "global.images.renderPullSecrets" . | nindent 6 }}

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -26,6 +26,8 @@ preUpgradeHook:
   labels: {}
   ## -- Annotations to add to the upgrade Job
   annotations: {}
+  ## -- Annotations to add to the upgrade Job's pod
+  podAnnotations: { }
   # -- Specify image
   image:
     registry: k8s.gcr.io


### PR DESCRIPTION
## Pull request description 

Fix for https://github.com/kubeshop/helm-charts/issues/624. Adds the ability to set the annotations on the pre upgrade mongo upgrade job.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-