### PR TITLE
chore(charts/tracetest): update the way to inject env vars on Tracetest chart

### DIFF
--- a/charts/tracetest/templates/configmap.yaml
+++ b/charts/tracetest/templates/configmap.yaml
@@ -6,10 +6,6 @@ metadata:
     {{- include "tracetest.labels" . | nindent 4 }}
 data:
   config.yaml: |-
-    poolingConfig:
-      {{- toYaml .Values.poolingConfig | nindent 6 }}
-    googleAnalytics:
-      enabled: {{.Values.analytics.enabled}}
     postgres:
       host: {{ include "tracetest.postgresql.fullname" . }}
       user: {{.Values.postgresql.auth.username}}

--- a/charts/tracetest/templates/deployment.yaml
+++ b/charts/tracetest/templates/deployment.yaml
@@ -33,8 +33,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           env:
-          - name: TRACETEST_DEV
-            value: "{{ .Values.env.tracetestDev }}"
+          {{- toYaml .Values.environmentVars | nindent 10 }}
           args:
           - --config
           - '/app/config/config.yaml'

--- a/charts/tracetest/values.yaml
+++ b/charts/tracetest/values.yaml
@@ -66,24 +66,6 @@ provisioning: |
       cartEndpoint: http://otel-cartservice.otel-demo:7070
       checkoutEndpoint: http://otel-checkoutservice.otel-demo:5050
 
-
-# This section configures the strategy for pooling traces from the trace backend
-poolingConfig:
-  # How long tracetest will wait for a complete trace before timing out
-  # If you have long-running operations that will generate part of your trace, you have
-  # to change this attribute to be greater than the execution time of your operation.
-  maxWaitTimeForTrace: 30s
-
-  # How long tracetest will wait to retry fetching the trace. If you define it as 5s it means that
-  # tracetest will retrieve the operation trace every 5 seconds and check if it's complete. It will
-  # do that until the operation times out.
-  retryDelay: 5s
-
-# Section for anonymous analytics. If it's enabled, tracetest will collect anonymous analytics data
-# to help us improving our project. If you don't want to send analytics data, set enabled as false.
-analytics:
-  enabled: true
-
 # Section to configure how telemetry works in Tracetest.
 telemetry:
   # exporters are opentelemetry exporters. It configures how tracetest generates and send telemetry to
@@ -131,8 +113,9 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-env:
-  tracetestDev: ""
+environmentVars:
+  - name: TRACETEST_DEV
+    value: "false"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Pull request description 

This PR removes old configs from our charts (`analytic ` and `pollingProfile` that where moved to the Resources API) and adds a new way to inject env vars on Tracetest, which can help us to update its internal configuration.

### How to test it

1. Go to the `./charts` folder
2. Run the command: 
```sh
helm template tracetest ./tracetest --values ./tracetest/values.yaml
```
3. At the output, you should see the Tracetest deployment with the following config:
```yaml
# ...

---
# Source: tracetest/templates/deployment.yaml
apiVersion: apps/v1

# ...
      containers:
        - name: tracetest
          securityContext:
            {}
          image: "kubeshop/tracetest:v0.13.8"
          env:
          - name: TRACETEST_DEV
            value: "false"
# ...
```