### PR TITLE
chore(tracetest): adding option to disable pg installation

### DIFF
--- a/charts/tracetest/Chart.yaml
+++ b/charts/tracetest/Chart.yaml
@@ -10,7 +10,7 @@ sources:
 dependencies:
   - name: postgresql
     version: 12.1.6
-    # condition: postgresql.enabled
+    condition: postgresql.enabled
     repository: "https://charts.bitnami.com/bitnami"
 
 # A chart can be either an 'application' or a 'library' chart.
@@ -26,7 +26,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.78
+version: 0.2.79
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tracetest/templates/configmap.yaml
+++ b/charts/tracetest/templates/configmap.yaml
@@ -6,12 +6,14 @@ metadata:
     {{- include "tracetest.labels" . | nindent 4 }}
 data:
   config.yaml: |-
+    {{- if .Values.postgresql.enabled }}
     postgres:
       host: {{ include "tracetest.postgresql.fullname" . }}
       user: {{.Values.postgresql.auth.username}}
       password: {{.Values.postgresql.auth.password}}
       port: 5432
       params: sslmode=disable
+    {{- end }}
     telemetry:
       {{- toYaml .Values.telemetry | nindent 6 }}
     server:


### PR DESCRIPTION
## Pull request description 

Add an option to avoid installing postgres with tracetest.

### How to test it

#### Installation with Postgres

1. Go to the `./charts` folder
2. Run the command: 
```sh
helm template tracetest ./tracetest --values ./tracetest/values.yaml
```
3. At the output, you should see the Tracetest deployment with a postgres installation normally.

#### Installation without Postgres

1. Create a `values.yaml` file with the following options:
```yaml
postgresql:
  enabled: false

environmentVars:
  - name: TRACETEST_TESTPIPELINES_TRIGGEREXECUTE_ENABLED
    value: "false"
  - name: TRACETEST_TESTPIPELINES_TRACEFETCH_ENABLED
    value: "false"
  - name: TRACETEST_POSTGRES_DBNAME
    value: "tracetest"
  - name: TRACETEST_POSTGRES_HOST
    value: "10.92.0.3"
  - name: TRACETEST_POSTGRES_USER
    value: "my-user"
  - name: TRACETEST_POSTGRES_PASSWORD
    value: "my-password"
  - name: TRACETEST_POSTGRES_PORT
    value: "5432"
```
2. Go to the `./charts` folder
3. Run the command: 
```sh
helm template tracetest ./tracetest --values ./path-to-my-values.yaml
```
3. At the output, you should see the Tracetest deployment without a postgres installation normally.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-