### PR TITLE
Add helm values to read cloud properties from existing secret

### DIFF
--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -234,21 +234,42 @@ spec:
               value:  "{{ .Values.cliIngress.oauth.provider }}"
             - name: TESTKUBE_OAUTH_SCOPES
               value:  "{{ .Values.cliIngress.oauth.scopes }}"
-            {{- if .Values.cloud.key }}
+            {{- if .Values.cloud.key and not .Values.cloud.existingSecret.key }}
             - name: TESTKUBE_CLOUD_API_KEY
               value:  "{{ .Values.cloud.key }}"
+            {{- end}}
+            {{- if .Values.cloud.existingSecret.key }}
+            - name: TESTKUBE_CLOUD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: {{ .Values.cloud.existingSecret.key }}
+                  name: {{ .Values.cloud.existingSecret.name }}
             {{- end}}
             {{- if .Values.cloud.url }}
             - name: TESTKUBE_CLOUD_URL
               value:  "{{ .Values.cloud.url }}"
             {{- end}}
-            {{- if .Values.cloud.orgId }}
+            {{- if .Values.cloud.orgId and not .Values.cloud.existingSecret.orgId }}
             - name: TESTKUBE_CLOUD_ORG_ID
               value:  "{{ .Values.cloud.orgId }}"
             {{- end}}
-            {{- if .Values.cloud.envId }}
+            {{- if .Values.cloud.existingSecret.orgId }}
+            - name: TESTKUBE_CLOUD_ORG_ID
+              valueFrom:
+                secretKeyRef:
+                  key: {{ .Values.cloud.existingSecret.orgId }}
+                  name: {{ .Values.cloud.existingSecret.name }}
+            {{- end}}
+            {{- if .Values.cloud.envId and not .Values.cloud.existingSecret.envId }}
             - name: TESTKUBE_CLOUD_ENV_ID
               value:  "{{ .Values.cloud.envId }}"
+            {{- end}}
+            {{- if .Values.cloud.existingSecret.envId }}
+            - name: TESTKUBE_CLOUD_ENV_ID
+              valueFrom:
+                secretKeyRef:
+                  key: {{ .Values.cloud.existingSecret.envId }}
+                  name: {{ .Values.cloud.existingSecret.name }}
             {{- end}}
             {{- if .Values.cloud.migrate }}
             - name: TESTKUBE_CLOUD_MIGRATE

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -67,6 +67,16 @@ cloud:
   envId: ""
   ## true if migration from OSS
   migrate: ""
+  ## Retrieve cloud information from existing secret
+  existingSecret:
+    ## Name of the secret. If set, this will be used instead of the above values
+    name: ""
+    ## Key for the License Key
+    key: ""
+    ## Key for the Organization ID
+    orgId: ""
+    ## Key for the Environment ID
+    envId: ""
 
 ## Multinamespace feature. Disabled by default
 multinamespace:


### PR DESCRIPTION
We manage our applications using GitOps. Directly referencing a value from helm values would require us to place the secrets into Git. To resolve this, we will manage the secret using external-secret and make testkube reference that secret.

## Pull request description 
Add helm values to use cloud properties from existing secret instead of helm values


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-