### PR TITLE
build: mongo upgrade to app version 6.0.5

### DIFF
--- a/charts/testkube/Chart.yaml
+++ b/charts/testkube/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     condition: testkube-operator.enabled
   - name: mongodb
     condition: mongodb.enabled
-    version: 12.1.31
+    version: 13.10.1
     repository: https://charts.bitnami.com/bitnami
   - name: nats
     condition: testkube-api.nats.enabled

--- a/charts/testkube/templates/pre-upgrade.yaml
+++ b/charts/testkube/templates/pre-upgrade.yaml
@@ -60,7 +60,7 @@ spec:
         - -c
         - >
             export current_mongodb_version=$(kubectl get deployment {{ .Release.Name }}-mongodb -o=jsonpath='{$.spec.template.metadata.labels}' -n {{ .Release.Namespace }} | awk -F'helm.sh/chart' '{print $2}' | awk -F'[^0-9]+' '{ print $2 }');
-            if [ "$current_mongodb_version" -eq "11" ];
+            if [ "$current_mongodb_version" -eq "12" ];
               then kubectl scale deployment {{ .Release.Name }}-mongodb --replicas=0 -n {{ .Release.Namespace }};
               else echo "MongoDB is up-to-date";
             fi

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -87,7 +87,7 @@ mongodb:
     # -- MongoDB image repository
     repository: zcube/bitnami-compat-mongodb
     # -- MongoDB image tag
-    tag: 5.0.10-debian-11-r19
+    tag: 6.0.5-debian-11-r64
   # ref: https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-arm-workloads-for-deployment#node-affinity-multi-arch-arm
   # -- Tolerations to schedule a workload to nodes with any architecture type. Required for deployment to GKE cluster.
   tolerations:


### PR DESCRIPTION
## Pull request description 
Upgrade Mongo to 6.0.5
Image: docker.io/zcube/bitnami-compat-mongodb:6.0.5-debian-11-r64 (supports ARM and AMD)
Chart version: mongodb-13.10.1 (released on 27 Apr, 2023)


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes
## Changes

-

## Fixes

-