### PR TITLE
feat(tracetest): allow configMapOverride

### DIFF
--- a/charts/tracetest/templates/_helpers.tpl
+++ b/charts/tracetest/templates/_helpers.tpl
@@ -23,6 +23,16 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
+
+{{- define "tracetest.config-map-name" -}}
+{{- if .Values.configMapOverride }}
+{{- .Values.configMapOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- include "tracetest.fullname" . }}
+{{- end }}
+{{- end -}}
+
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/tracetest/templates/configmap.yaml
+++ b/charts/tracetest/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.configMapOverride }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -21,3 +22,4 @@ data:
   provisioning.yaml: |-
     {{- toYaml .Values.provisioning | nindent 4 }}
 ---
+{{- end }}

--- a/charts/tracetest/templates/deployment.yaml
+++ b/charts/tracetest/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ include "tracetest.fullname" . }}
+          name: {{ include "tracetest.config-map-name" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/tracetest/values.yaml
+++ b/charts/tracetest/values.yaml
@@ -14,7 +14,9 @@ postgresql:
     password: not-secure-database-password
     existingSecret: ""
 
-# Provisioning allows to define initial settings to be loaded into the database on first run. 
+
+
+# Provisioning allows to define initial settings to be loaded into the database on first run.
 # These will only be applied when running tracetest against an empty database. If tracetest has already
 # been configured, the provisioning settings are ignored.
 provisioning: |
@@ -120,6 +122,8 @@ environmentVars:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+# If set, it allows to pass a custom configmap to the tracetest server
+configMapOverride: ""
 serviceAccount:
   # Specifies whether a service account should be created
   create: false


### PR DESCRIPTION
## Pull request description 

Add an option to override the referenced configmap name. This allows for users to create a custom configmap externally and reference it in this chart. 

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
