### PR TITLE
[tracetest] feat: allow configuring external postgres

### DIFF
--- a/charts/tracetest/Chart.yaml
+++ b/charts/tracetest/Chart.yaml
@@ -26,7 +26,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.90
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tracetest/templates/_helpers.tpl
+++ b/charts/tracetest/templates/_helpers.tpl
@@ -57,7 +57,11 @@ Create a default fully qualified postgresql name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "tracetest.postgresql.fullname" -}}
-{{- include "common.names.dependency.fullname" (dict "chartName" "postgresql" "chartValues" .Values.postgresql "context" $) -}}
+{{- if .Values.postgresql.enabled }}
+    {{- include "common.names.dependency.fullname" (dict "chartName" "postgresql" "chartValues" .Values.postgresql "context" $) -}}
+{{- else -}}
+    {{- .Values.postgresql.auth.host -}}
+{{- end -}}
 {{- end -}}
 
 

--- a/charts/tracetest/templates/configmap.yaml
+++ b/charts/tracetest/templates/configmap.yaml
@@ -7,14 +7,12 @@ metadata:
     {{- include "tracetest.labels" . | nindent 4 }}
 data:
   config.yaml: |-
-    {{- if .Values.postgresql.enabled }}
     postgres:
       host: {{ include "tracetest.postgresql.fullname" . }}
       user: {{.Values.postgresql.auth.username}}
       password: {{.Values.postgresql.auth.password}}
-      port: 5432
-      params: sslmode=disable
-    {{- end }}
+      port: {{.Values.postgresql.auth.port}}
+      params: {{.Values.postgresql.auth.params}}
     telemetry:
       {{- toYaml .Values.telemetry | nindent 6 }}
     server:

--- a/charts/tracetest/values.yaml
+++ b/charts/tracetest/values.yaml
@@ -1,7 +1,8 @@
 # Section for configuring the postgres database that will be used by Tracetest
 postgresql:
-  # For now, this is required to be enabled, otherwise tracetest will not
-  # be able to function properly.
+  # if enabled is true, the postgres chart will be installed.
+  # it can be turned off if you already have a postgres database running.
+  # In that case, you need to pass the values for `postgres.auth`
   enabled: true
   architecture: standalone
   image:
@@ -9,6 +10,10 @@ postgresql:
 
   # credentials for accessing the database
   auth:
+    # host is only required if not using the postgres chart
+    host: ""
+    port: 5432
+    params: sslmode=disable
     database: "tracetest"
     username: "tracetest"
     password: not-secure-database-password


### PR DESCRIPTION
## Pull request description 

This PR allows to configure an external postgres database more easily. To do so, users need to disable the dependent chart and set the correct hostname. Example `values.yaml` file:

```yaml
postgres:
  enabled: false # disable the postgres chart install
  auth:
    host: mypg.example.com #this is a new parameter
    username: myuser
    password: mypass

# ...
```

## Checklist (choose whats happened)

- [x] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

The behavior of the `ConfigMap` was changed: Before, it would not include the postgres settings if the chart was disabled. Now we always include them.
