### PR TITLE
testkube: add support for connecting to agent in insecure mode and skipping cert validation

### DIFF
--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -276,7 +276,15 @@ spec:
             {{- if .Values.cloud.url }}
             - name: TESTKUBE_CLOUD_URL
               value:  "{{ .Values.cloud.url }}"
-            {{- end}}
+            {{- end }}
+            {{- if not .Values.cloud.tls.enabled }}
+            - name: TESTKUBE_PRO_TLS_INSECURE
+              value:  "true"
+            {{- end }}
+            {{- if .Values.cloud.tls.skipVerify }}
+            - name: TESTKUBE_PRO_SKIP_VERIFY
+              value:  "true"
+            {{- end }}
             {{- if .Values.cloud.orgId }}
             - name: TESTKUBE_CLOUD_ORG_ID
               value:  "{{ .Values.cloud.orgId }}"

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -53,7 +53,7 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
-## Custom job-template.yml that will passed to Testkube API
+## Custom job-template.yml that will be passed to Testkube API
 configValues: ""
 
 ## Testkube API Deployment parameters
@@ -69,6 +69,11 @@ cloud:
   envId: ""
   ## true if migration from OSS
   migrate: ""
+  tls:
+    ## Toggle should the connection to Agent API in Cloud/Enterprise use secure GRPC (GRPCS) (if false, it will use insecure GRPC)
+    enabled: true
+    ## Toggle should the client skip verifying the Agent API server cert in Cloud/Enterprise
+    skipVerify: false
   ## Retrieve cloud information from existing secret
   existingSecret:
     ## Name of the secret. If set, this will be used instead of the above values
@@ -117,7 +122,7 @@ templates:
   ## Base64 encoded PVC Container template
   pvcContainer: ""
    ## Base64 encoded Slave Pod template
-  slavePod: "" 
+  slavePod: ""
 
 ## base64 encoded executors.json alike data
 executors: ""

--- a/charts/testkube/README.md
+++ b/charts/testkube/README.md
@@ -2,7 +2,7 @@
 
 Testkube is an open-source platform that simplifies the deployment and management of automated testing infrastructure.
 
-![Version: 1.16.7](https://img.shields.io/badge/Version-1.16.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.16.18](https://img.shields.io/badge/Version-1.16.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Install
 
@@ -136,9 +136,9 @@ kubectl label --overwrite crds scripts.tests.testkube.io app.kubernetes.io/manag
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../global | global | 0.1.2 |
-| file://../testkube-api | testkube-api | 1.16.8 |
-| file://../testkube-dashboard | testkube-dashboard | 1.15.0 |
-| file://../testkube-operator | testkube-operator | 1.16.0 |
+| file://../testkube-api | testkube-api | 1.16.13 |
+| file://../testkube-dashboard | testkube-dashboard | 1.16.2 |
+| file://../testkube-operator | testkube-operator | 1.16.11 |
 | https://charts.bitnami.com/bitnami | mongodb | 13.10.1 |
 | https://nats-io.github.io/k8s/helm/charts/ | nats | 0.19.1 |
 
@@ -203,6 +203,8 @@ kubectl label --overwrite crds scripts.tests.testkube.io app.kubernetes.io/manag
 | testkube-api.cliIngress.tls | list | `[]` | Placing a host in the TLS config will indicate a certificate should be created |
 | testkube-api.cliIngress.tlsenabled | bool | `false` | Toggle whether to enable TLS on the ingress |
 | testkube-api.cloud.key | string | `""` | Testkube Clouc License Key (for Environment) |
+| testkube-api.cloud.tls.enabled | bool | `true` | Toggle should the connection to Agent API in Cloud/Enterprise use secure GRPC (GRPCS) (if false, it will use insecure GRPC) |
+| testkube-api.cloud.tls.skipVerify | bool | `false` | Toggle should the client skip verifying the Agent API server cert in Cloud/Enterprise |
 | testkube-api.cloud.url | string | `"agent.testkube.io:443"` | Testkube Cloud API URL |
 | testkube-api.clusterName | string | `""` |  |
 | testkube-api.dashboardUri | string | `""` |  |

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -276,6 +276,11 @@ testkube-api:
     url: "agent.testkube.io:443"
     # -- Testkube Clouc License Key (for Environment)
     key: ""
+    tls:
+      # -- Toggle should the connection to Agent API in Cloud/Enterprise use secure GRPC (GRPCS) (if false, it will use insecure GRPC)
+      enabled: true
+      # -- Toggle should the client skip verifying the Agent API server cert in Cloud/Enterprise
+      skipVerify: false
 
   # ref: https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-arm-workloads-for-deployment#node-affinity-multi-arch-arm
   # -- Tolerations to schedule a workload to nodes with any architecture type. Required for deployment to GKE cluster.


### PR DESCRIPTION

## Pull request description 

add support for connecting to agent in insecure mode and skipping cert validation
- set `testkube-api.cloud.tls.enabled=true|false` whether you want to connect with GRPCS or GRPC respectively
- set `testkube-api.cloud.tls.skipVerify=true|false` whether you want to skip server cert validation 


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-