### PR TITLE
feat(testkube): Add support for Kubernetes secrets

### DIFF
--- a/charts/testkube/templates/secret.yaml
+++ b/charts/testkube/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.secrets }}
+{{- range $k, $v := .Values.secrets }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $k }}-secret
+type: Opaque
+data:
+{{- range $name, $val := $v }}
+  {{ $name }}: {{ $val | b64enc }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -1192,3 +1192,5 @@ testkube-operator:
         operator: Equal
         value: arm64
         effect: NoSchedule
+# Manage Kubernetes secrets
+secrets: {}


### PR DESCRIPTION
## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

- N/A

## Changes

- Support creating Kubernetes secrets.

## Fixes

- N/A

## Additional Information

As I want to persist various secrets like Github tokens, AWS creds, etc, I figured it best to keep the structure data-agnostic.

```
❯ cat /tmp/secrets.yaml
secrets:
  a:
    b: c
    c: d
  b:
    foo: bar

❯ helm template charts/testkube -f /tmp/secrets.yaml -s templates/secret.yaml
---
# Source: testkube/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: a-secret
type: Opaque
data:
  b: Yw==
  c: ZA==---
---
# Source: testkube/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: b-secret
type: Opaque
data:
  foo: YmFy---
```