### PR TITLE
fix: allow external NATS

### DIFF
--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -111,9 +111,10 @@ spec:
             {{- end }}
             - name: API_MONGO_ALLOW_DISK_USE
               value: "{{ .Values.mongodb.allowDiskUse }}"
-            {{- if .Values.nats.enabled }}
             - name: NATS_URI
-              {{- if .Values.nats.secretName }}
+              {{- if .Values.nats.uri }}
+              value: "{{ .Values.nats.uri }}"
+              {{- else if .Values.nats.secretName }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.nats.secretName }}
@@ -131,7 +132,6 @@ spec:
             {{- if .Values.nats.tls.mountCACertificate }}
             - name: "NATS_CA_FILE"
               value: "{{ .Values.nats.tls.certSecret.baseMountPath }}/{{ .Values.nats.tls.certSecret.caFile }}"
-            {{- end }}
             {{- end }}
             {{- end }}
             - name: POSTMANEXECUTOR_URI

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -348,6 +348,8 @@ nats:
   ## load URI from secrets
   # secretName: XXX
   # secretKey: XXX
+  ## load URI from plain-text
+  # uri: "nats://testkube-nats:4222"
 
 ## MINIO parameters
 minio:

--- a/charts/testkube-operator/templates/deployment.yaml
+++ b/charts/testkube-operator/templates/deployment.yaml
@@ -83,17 +83,6 @@ spec:
         - name: APISERVER_REGISTRY
           value:  {{ .Values.global.imageRegistry }}
         {{- end }}
-        {{- if .Values.nats.enabled }}
-        - name: NATS_URI
-          {{- if .Values.nats.secretName }}
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.nats.secretName }}
-              key: {{ .Values.nats.secretKey }}
-          {{- else }}
-          value: "nats://{{ .Release.Name }}-nats"
-          {{- end }}
-        {{- end }}
         ports:
         - containerPort: 9443
           name: webhook-server

--- a/charts/testkube-operator/values.yaml
+++ b/charts/testkube-operator/values.yaml
@@ -333,12 +333,3 @@ preUpgrade:
       operator: Equal
       value: arm64
       effect: NoSchedule
-
-## NATS parameters
-## ref: https://github.com/nats-io/nats-server
-nats:
-  ## Deploy NATS server to the cluster
-  enabled: true
-  ## load URI from secrets
-  # secretName: XXX
-  # secretKey: XXX

--- a/charts/testkube/README.md
+++ b/charts/testkube/README.md
@@ -67,6 +67,20 @@ testkube-api:
       skipVerify: true
 ```
 
+To use external NATS server, it's possible to configure:
+
+```yaml
+testkube-api:
+  nats:
+    enabled: false
+    uri: nats://some-nats-address:4222
+    # # or providing URI with Kubernetes secret:
+    # secretName: example-secret
+    # secretKey: example-key
+
+    # […] other options like `tls`
+```
+
 #### MinIO/S3
 
 Currently, Testkube doesn't support provisioning MinIO with TLS. However, if you use an external MinIO (or any S3-compatible storage)

--- a/charts/testkube/README.md.gotmpl
+++ b/charts/testkube/README.md.gotmpl
@@ -66,6 +66,20 @@ testkube-api:
       skipVerify: true
 ```
 
+To use external NATS server, it's possible to configure:
+
+```yaml
+testkube-api:
+  nats:
+    enabled: false
+    uri: nats://some-nats-address:4222
+    # # or providing URI with Kubernetes secret:
+    # secretName: example-secret
+    # secretKey: example-key
+
+    # […] other options like `tls`
+```
+
 #### MinIO/S3
 
 Currently, Testkube doesn't support provisioning MinIO with TLS. However, if you use an external MinIO (or any S3-compatible storage)


### PR DESCRIPTION
## Pull request description 

* Allow passing external NATS details even when `nats.enabled: false` (so the NATS server is not deployed)
* Allow passing external NATS server with `nats.uri`

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
