### PR TITLE
fix: allow setting pathtype for testkube api and dashboard ingress

### DIFF
--- a/charts/testkube-api/templates/ui-ingress.yaml
+++ b/charts/testkube-api/templates/ui-ingress.yaml
@@ -43,7 +43,7 @@ spec:
       http:
         paths:
           - path: {{ $.Values.uiIngress.path }}
-            pathType: Prefix
+            pathType: {{ default Prefix $.Values.uiIngress.pathType }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.Version }}
               service:

--- a/charts/testkube-api/templates/ui-ingress.yaml
+++ b/charts/testkube-api/templates/ui-ingress.yaml
@@ -43,7 +43,7 @@ spec:
       http:
         paths:
           - path: {{ $.Values.uiIngress.path }}
-            pathType: {{ default Prefix $.Values.uiIngress.pathType }}
+            pathType: {{ default "Prefix" $.Values.uiIngress.pathType }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.Version }}
               service:

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -449,6 +449,8 @@ uiIngress:
   annotations: {}
   ## The Path to Nginx.
   path: /results/(v\d/executions.*)
+  ## The PathType to Nginx.
+  pathType: Prefix
   ## Hostnames must be provided if Ingress is enabled.
   hosts: []
   # - testkube.example.com

--- a/charts/testkube-dashboard/templates/ingress.yaml
+++ b/charts/testkube-dashboard/templates/ingress.yaml
@@ -43,7 +43,7 @@ spec:
       http:
         paths:
           - path: {{ $.Values.ingress.path }}
-            pathType: Prefix
+            pathType: {{ default Prefix $.Values.ingress.pathType }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.Version }}
               service:

--- a/charts/testkube-dashboard/templates/ingress.yaml
+++ b/charts/testkube-dashboard/templates/ingress.yaml
@@ -43,7 +43,7 @@ spec:
       http:
         paths:
           - path: {{ $.Values.ingress.path }}
-            pathType: {{ default Prefix $.Values.ingress.pathType }}
+            pathType: {{ default "Prefix" $.Values.ingress.pathType }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.Version }}
               service:

--- a/charts/testkube-dashboard/values.yaml
+++ b/charts/testkube-dashboard/values.yaml
@@ -113,6 +113,8 @@ ingress:
   annotations: {}
   ## The Path to Nginx.
   path: /
+  ## The PathType to Nginx.
+  pathType: Prefix
   ## Hostnames must be provided if Ingress is enabled.
   hosts: []
   #  - testkube.example.com


### PR DESCRIPTION
closes #709

## Pull request description 
Changes Ingress for testkube api and testkube dashboard ingress pathtype


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-