### PR TITLE
tolerations and nodeSelector for cronjob-template.yml.

### DIFF
--- a/charts/testkube-operator/cronjob-template.yml
+++ b/charts/testkube-operator/cronjob-template.yml
@@ -33,5 +33,13 @@ spec:
             args:
             - 'curl -X POST -H "Content-Type: application/json" -d ''{{ .Data }}'' "http://{{ .ServiceName }}:{{ .ServicePort}}/v1/{{ .ResourceURI }}/{{ .Id }}/executions"'
           restartPolicy: Never
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       backoffLimit: 0
       ttlSecondsAfterFinished: 180


### PR DESCRIPTION
## Pull request description 
CronJobs can't start pods with curl to run tests in more restricted environments so I've added tolerations and nodeSelector here from values to fix this issue.

I think the fix doesn't need any changes in doc but if so please inform me. I can add.

I've rendered this change and it looks good. I'll check it on cluster soon but I opened this PR earlier in case of any feedback.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

- Missing tolerations and nodeSelector added to test's CronJob.