### PR TITLE
feat: Grant read access to metrics.k8s.io API

### DIFF
--- a/charts/testkube-api/templates/role.yaml
+++ b/charts/testkube-api/templates/role.yaml
@@ -645,4 +645,13 @@ rules:
       - list
       - create
       - delete
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
 {{- end }}


### PR DESCRIPTION
## Pull request description 

Allows test pods to query the metrics.k8s.io API. This is especially handy since it allows for a curl executor to query metrics-server in order to ensure metrics are being collected for the pod. This makes no attempt to handle or provide for authentication (possible via the service account's token). This simply handles the authorization piece.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

- None

## Changes

-

## Fixes

-