### PR TITLE
feat: [TKC-1455] disable mongo pre-upgrade job if mongodb is disabled

### DIFF
--- a/charts/testkube/templates/pre-upgrade-sa.yaml
+++ b/charts/testkube/templates/pre-upgrade-sa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.preUpgradeHook.serviceAccount.create }}
+{{- if and .Values.preUpgradeHook.serviceAccount.create .Values.mongodb.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -14,7 +14,7 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 {{- end }}
 
-{{- if .Values.preUpgradeHook.serviceAccount.create }}
+{{- if and .Values.preUpgradeHook.serviceAccount.create .Values.mongodb.enabled }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -35,7 +35,7 @@ rules:
     verbs: ["create","delete","get","list","patch","update","watch"]
 {{- end }}
 
-{{- if .Values.preUpgradeHook.serviceAccount.create }}
+{{- if and .Values.preUpgradeHook.serviceAccount.create .Values.mongodb.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/testkube/templates/pre-upgrade.yaml
+++ b/charts/testkube/templates/pre-upgrade.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.preUpgradeHook.enabled -}}
+{{- if and .Values.preUpgradeHook.enabled .Values.mongodb.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
## Pull request description 
Disable mongo pre-upgrade job if MongoDB is disabled.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-