### PR TITLE
fix: rename cloud tls var name

### DIFF
--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -310,7 +310,7 @@ spec:
               value: "{{ .Values.cloud.uiUrl }}"
             {{- end}}
             {{- if not .Values.cloud.tls.enabled }}
-            - name: TESTKUBE_PRO_TLS_INSECURE
+            - name: TESTKUBE_CLOUD_TLS_INSECURE
               value:  "true"
             {{- end }}
             {{- if .Values.cloud.tls.skipVerify }}


### PR DESCRIPTION
## Pull request description 
Renamed TESTKUBE_PRO_TLS_INSECURE to TESTKUBE_CLOUD_TLS_INSECURE as it was not used by the application. 


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-