### PR TITLE
fix: add missing roles for TestWorkflows

### DIFF
--- a/charts/testkube-api/templates/role.yaml
+++ b/charts/testkube-api/templates/role.yaml
@@ -259,6 +259,7 @@ rules:
       - get
       - patch
       - update
+      - deletecollection
 
 ---
 

--- a/charts/testkube-operator/templates/role.yaml
+++ b/charts/testkube-operator/templates/role.yaml
@@ -399,6 +399,48 @@ rules:
   - watch
   - deletecollection
 
+---
+
+apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-testworkflows-role
+  labels:
+    {{- if .Values.global.labels }}
+    {{- include "global.tplvalues.render" ( dict "value" .Values.global.labels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.global.annotations }}
+  annotations: {{- include "global.tplvalues.render" ( dict "value" .Values.global.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  namespace: {{ include "testkube-operator.namespace" . }}
+rules:
+  - apiGroups:
+      - testworkflows.testkube.io
+    resources:
+      - testworkflows
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      - deletecollection
+  - apiGroups:
+      - testworkflows.testkube.io
+    resources:
+      - testworkflowtemplates
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      - deletecollection
+
 {{- if and .Values.webhook.enabled .Values.webhook.patch.enabled }}
 ---
 apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}

--- a/charts/testkube-operator/templates/rolebinding.yaml
+++ b/charts/testkube-operator/templates/rolebinding.yaml
@@ -91,6 +91,29 @@ subjects:
   name: {{ include "testkube-operator.serviceAccountName" . }}
   namespace: {{ include "testkube-operator.namespace" . }}
 
+---
+
+apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-testworkflows-rolebinding
+  labels:
+  {{- if .Values.global.labels }}
+  {{- include "global.tplvalues.render" ( dict "value" .Values.global.labels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.global.annotations }}
+  annotations: {{- include "global.tplvalues.render" ( dict "value" .Values.global.annotations "context" $ ) | nindent 4 }}
+  {{- end }}
+  namespace: {{ include "testkube-operator.namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-testworkflows-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "testkube-operator.serviceAccountName" . }}
+  namespace: {{ include "testkube-operator.namespace" . }}
+
 {{- if and .Values.webhook.enabled .Values.webhook.patch.enabled }}
 ---
 apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}


### PR DESCRIPTION
## Pull request description 

* Add missing permission for ConfigMaps `deletecollection` (for bulk cleanup of TestWorkflows resources)
* Add TestWorkflow permissions for `testkube-operator`
