### PR TITLE
fix: typo - Role instead of ClusterRole

### DIFF
--- a/charts/testkube-operator/templates/role.yaml
+++ b/charts/testkube-operator/templates/role.yaml
@@ -402,7 +402,7 @@ rules:
 ---
 
 apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
-kind: Role
+kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}-testworkflows-role
   labels:


### PR DESCRIPTION
## Pull request description 

Used `Role` instead of `ClusterRole` for operator's RBAC