### PR TITLE
feat: add an option to provide nameselector and scope in operator webhook

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,9 @@
 ## Reference: https://github.com/helm/chart-testing-action
 name: Lint
-on: pull_request
+on:
+  pull_request:
+    branches:
+      - develop
 
 permissions:
   contents: write
@@ -11,19 +14,19 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
         with:
-          version: v3.10.1
+          version: v3.14.1
 
-      - name: Set up python
-        uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0 # v4.6.1
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.10'
+          check-latest: true
 
       - name: Setup Chart Linting
         uses: helm/chart-testing-action@v2.6.0
@@ -34,7 +37,7 @@ jobs:
         id: list-changed
         run: |
           ## If executed with debug this won't work anymore.
-          changed=$(ct --target-branch ${{ github.event.pull_request.head.ref }} --config ./.github/configs/ct-lint.yaml list-changed)
+          changed=$(ct --target-branch develop --config ./.github/configs/ct-lint.yaml list-changed)
           charts=$(echo "$changed" | tr '\n' ' ' | xargs)
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> $GITHUB_OUTPUT
@@ -42,4 +45,4 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --debug --target-branch ${{ github.event.pull_request.head.ref }} --config ./.github/configs/ct-lint.yaml --lint-conf ./.github/configs/lintconf.yaml
+        run: ct lint --debug --target-branch develop --config ./.github/configs/ct-lint.yaml --lint-conf ./.github/configs/lintconf.yaml

--- a/charts/testkube-operator/templates/webhook.yaml
+++ b/charts/testkube-operator/templates/webhook.yaml
@@ -23,6 +23,10 @@ webhooks:
 - admissionReviewVersions:
   - v1
   - v1beta1
+  {{- if .Values.webhook.namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml .Values.webhook.namespaceSelector | nindent 4 }}
+  {{- end }}
   clientConfig:
     service:
       name: {{ include "testkube-operator.webhookServiceName" . }}
@@ -40,5 +44,6 @@ webhooks:
     - UPDATE
     resources:
     - testtriggers
+    scope: Namespaced
   sideEffects: None
 {{- end }}

--- a/charts/testkube-operator/values.yaml
+++ b/charts/testkube-operator/values.yaml
@@ -146,6 +146,8 @@ webhook:
   enabled: true
   ## Name of the webhook
   name: webhook-admission
+  ## Limit which requests for namespaced resources are intercepted, by specifying a namespaceSelector.
+  namespaceSelector: {}
   ## Webhook specific labels
   labels: {}
   ## Webhook specific annotations

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -1160,6 +1160,8 @@ testkube-operator:
     enabled: true
     # -- Name of the webhook
     name: testkube-operator-webhook-admission
+    ## Limit which requests for namespaced resources are intercepted, by specifying a namespaceSelector.
+    namespaceSelector: {}
     # -- Webhook specific labels
     labels: {}
     # -- Webhook specific annotations


### PR DESCRIPTION
Cherry-pick to main.

* add an option to provide nameselector and scope in operator webhook

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-