### PR TITLE
Feature: Add support for overriding NATS image options

### DIFF
--- a/charts/testkube/Chart.yaml
+++ b/charts/testkube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: testkube
 description: Testkube is an open-source platform that simplifies the deployment and management of automated testing infrastructure.
 type: application
-version: 1.17.7
+version: 1.17.8
 dependencies:
   - name: testkube-operator
     version: 1.17.1

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -158,6 +158,13 @@ mongodb:
 ## Tolerations to schedule a workload to nodes with any architecture type. Required for deployment to GKE cluster.
 ## More info: https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-arm-workloads-for-deployment#node-affinity-multi-arch-arm
 nats:
+  # -- Uncomment to override the NATS Server image options
+  # container:
+  #   image:
+  #     repository: nats
+  #     tag: 2.10.9-alpine
+  #     pullPolicy:
+  #     registry:
   # NATS Box container settings
   # TODO remove this container after tests on dev and stage
   # nats-box is A lightweight container with NATS utilities. It's not needed for nats server
@@ -166,6 +173,13 @@ nats:
   #   enabled: false
   natsBox:
     enabled: true
+    # -- Uncomment to override the NATS Box image options
+    # container:
+    #   image:
+    #     repository: natsio/nats-box
+    #     tag: 0.14.1
+    #     pullPolicy:
+    #     registry:
     # -- NATS Box tolerations settings
     podTemplate:
       merge:
@@ -185,6 +199,12 @@ nats:
   # Reloader container settings
   reloader:
     enabled: true
+    # -- Uncomment to override the NATS Server Config Reloader image options
+    # image:
+    #   repository: natsio/nats-server-config-reloader
+    #   tag: 0.14.1
+    #   pullPolicy:
+    #   registry:
 
 testkube-logs:
   # -- Testkube logs full name override


### PR DESCRIPTION
## Pull request description 
This pull request takes care of adding support for overriding the NATS subcharts image options i.e. enabling users to explicitly set repository, tag, pull policy, and registry for each of the images utilized (NATS server, NATS config reloader, and NATS Box).

It looks like NATS Box is due to be disabled in the near future but it may be useful to have support for this in the meantime until it is fully disabled, at which point this NATS Box image override logic could be removed. I have also not included override support for the NATS Prometheus exporter as it looks like this is not currently in use.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [X] tested locally - templated the chart locally to test rendering
- [X] tested on cluster - deployed with changes to a cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes
N/A
-

## Changes
Includes addition of commented out block to allow users to override NATS subchart image settings when required.
-

## Fixes
N/A
-