### PR TITLE
feat(testkube): add networkpolicy support

### DIFF
--- a/charts/testkube/templates/networkpolicy.yaml
+++ b/charts/testkube/templates/networkpolicy.yaml
@@ -118,7 +118,6 @@ spec:
           port: {{ .Values.mongodb.service.port }}
 ---
 {{- end -}}
-{{- if .Values.nats.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -140,7 +139,6 @@ spec:
         - protocol: TCP
           port: 4222
 ---
-{{- end -}}
 {{- if index .Values "testkube-dashboard" "enabled" -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/testkube/templates/networkpolicy.yaml
+++ b/charts/testkube/templates/networkpolicy.yaml
@@ -1,0 +1,162 @@
+{{- if .Values.networkPolicy.enabled -}}
+# this policy will be assigned to any pod in the namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: testkube-all
+  namespace: testkube
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: api-server
+            app.kubernetes.io/instance: testkube
+      ports:
+        - protocol: TCP
+          port: {{ index .Values "testkube-api" "service" "port" }}
+    - to:
+      - podSelector:
+          matchLabels:
+            app: testkube-minio-testkube
+      ports:
+        - protocol: TCP
+          port: {{ index .Values "testkube-api" "storage" "endpoint_port" }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: testkube-operator
+  namespace: testkube
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 9443
+---
+# API must accept connections from everything 
+# (e.g. kube-proxy, pods in this namespace, external ingress controller)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: testkube-api-server
+  namespace: testkube
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: api-server
+      app.kubernetes.io/instance: testkube
+  policyTypes:
+    - Egress
+    - Ingress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: nats
+              app.kubernetes.io/instance: testkube
+      ports:
+        - protocol: TCP
+          port: 4222
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: mongodb
+              app.kubernetes.io/instance: testkube
+      ports:
+        - protocol: TCP
+          port: {{ .Values.mongodb.service.port }}
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: {{ index .Values "testkube-api" "service" "port" }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: testkube-minio
+  namespace: testkube
+spec:
+  podSelector:
+    matchLabels:
+      app: testkube-minio-testkube
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: {{ index .Values "testkube-api" "storage" "endpoint_port" }}
+---
+{{- if .Values.mongodb.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: testkube-mongodb
+  namespace: testkube
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: mongodb
+      app.kubernetes.io/instance: testkube
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: testkube
+      ports:
+        - protocol: TCP
+          port: {{ .Values.mongodb.service.port }}
+---
+{{- end -}}
+{{- if .Values.nats.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: testkube-nats
+  namespace: testkube
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: nats
+      app.kubernetes.io/instance: testkube
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: testkube
+      ports:
+        - protocol: TCP
+          port: 4222
+---
+{{- end -}}
+{{- if index .Values "testkube-dashboard" "enabled" -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: testkube-dashboard
+  namespace: testkube
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: dashboard
+      app.kubernetes.io/instance: testkube
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: {{ index .Values "testkube-dashboard" "service" "port" }} 
+{{- end -}}
+{{- end -}}

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -1084,3 +1084,6 @@ testkube-operator:
         operator: Equal
         value: arm64
         effect: NoSchedule
+
+networkPolicy:
+  enabled: false


### PR DESCRIPTION
## Pull request description 

Adds [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) support


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

- none

## Changes

- none

## Fixes

- none

## Additional Info

This will be useful to those folks who use network policies with a default-deny configuration. Only Testkube-specific traffic has been accommodated for and by default, these resources will not be created (must enable in values.yaml). I came up with these rules by watching for _PacketDrop_ events (provided by kube-iptables-tailor) in the _testkube_ namespace while running my Test Suites, etc. Hopefully, I didn't miss anything! Also, I am still on 1.16.64 so I added support for the dashboard if enabled.

I didn't update the README as I came to believe it may be auto-generated. LMK if I'm wrong and I'll be happy to update accordingly.

To see the template rendered:
```
cat << EOF > /tmp/values.yaml
networkPolicy:
  enabled: true
EOF
```

Now from inside the testkube chart directory

```
helm template testkube . -f values.yaml -f /tmp/values.yaml -s templates/networkpolicy.yaml
```

