### PR TITLE
feat(TKC-1808): allow to pass `run.shell` for TestWorkflow commands

### DIFF
--- a/charts/testkube-operator/Chart.yaml
+++ b/charts/testkube-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: testkube-operator
 description: A Helm chart for the testkube-operator (installs needed CRDs only for now)
 type: application
-version: 1.17.8
+version: 1.17.9
 appVersion: 1.17.8
 dependencies:
   - name: global

--- a/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflows.yaml
+++ b/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflows.yaml
@@ -1234,6 +1234,9 @@ spec:
                                   type: string
                               type: object
                           type: object
+                        shell:
+                          description: script to run in a default shell for the container
+                          type: string
                         volumeMounts:
                           description: volume mounts to append to the container
                           items:
@@ -4956,6 +4959,9 @@ spec:
                                   type: string
                               type: object
                           type: object
+                        shell:
+                          description: script to run in a default shell for the container
+                          type: string
                         volumeMounts:
                           description: volume mounts to append to the container
                           items:
@@ -6254,6 +6260,9 @@ spec:
                                   type: string
                               type: object
                           type: object
+                        shell:
+                          description: script to run in a default shell for the container
+                          type: string
                         volumeMounts:
                           description: volume mounts to append to the container
                           items:

--- a/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflowtemplates.yaml
+++ b/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflowtemplates.yaml
@@ -1235,6 +1235,9 @@ spec:
                                   type: string
                               type: object
                           type: object
+                        shell:
+                          description: script to run in a default shell for the container
+                          type: string
                         volumeMounts:
                           description: volume mounts to append to the container
                           items:
@@ -4919,6 +4922,9 @@ spec:
                                   type: string
                               type: object
                           type: object
+                        shell:
+                          description: script to run in a default shell for the container
+                          type: string
                         volumeMounts:
                           description: volume mounts to append to the container
                           items:
@@ -6179,6 +6185,9 @@ spec:
                                   type: string
                               type: object
                           type: object
+                        shell:
+                          description: script to run in a default shell for the container
+                          type: string
                         volumeMounts:
                           description: volume mounts to append to the container
                           items:

--- a/charts/testkube/Chart.yaml
+++ b/charts/testkube/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: testkube
 description: Testkube is an open-source platform that simplifies the deployment and management of automated testing infrastructure.
 type: application
-version: 1.17.15
+version: 1.17.16
 dependencies:
   - name: testkube-operator
-    version: 1.17.8
+    version: 1.17.9
     #repository: https://kubeshop.github.io/helm-charts
     repository: "file://../testkube-operator"
     condition: testkube-operator.enabled


### PR DESCRIPTION
## Pull request description 

* Add `run.shell` option, that will be similar as direct `shell` operation
* operator: https://github.com/kubeshop/testkube-operator/pull/238

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Fixes

- https://linear.app/kubeshop/issue/TKC-1808/[testworkflows]-add-runshell-option