### PR TITLE
feat(TKC-1673): add headless service and CRDs for distributed pods in TestWorkflows

### DIFF
--- a/charts/testkube-api/Chart.yaml
+++ b/charts/testkube-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: testkube-api
 description: A Helm chart for Testkube api
 type: application
-version: 1.17.10
+version: 1.17.11
 appVersion: 1.17.10
 dependencies:
   - name: global

--- a/charts/testkube-api/templates/testworkflows/assisting-pods-service.yaml
+++ b/charts/testkube-api/templates/testworkflows/assisting-pods-service.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.global.testWorkflows.createAssistingPodsService }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: tkassist
+spec:
+  selector:
+    tkassist: 'true'
+  clusterIP: None
+{{- end }}

--- a/charts/testkube-api/templates/testworkflows/builtin-templates/serviceaccount.yaml
+++ b/charts/testkube-api/templates/testworkflows/builtin-templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.global.testWorkflows.createServiceAccountTemplates }}
+apiVersion: testworkflows.testkube.io/v1
+kind: TestWorkflowTemplate
+metadata:
+  name: serviceaccount--fullaccess
+spec:
+  pod:
+    serviceAccountName: {{ include "testkube-api.serviceAccountName" . }}
+{{- end }}

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -18,6 +18,7 @@ global:
     logsV2: false
   testWorkflows:
     createAssistingPodsService: true
+    createServiceAccountTemplates: true
 
 ### @section Common parameters
 ## Kubernetes version (using Helm capabilities if not set)

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -16,6 +16,8 @@ global:
   tolerations: []
   features:
     logsV2: false
+  testWorkflows:
+    createAssistingPodsService: true
 
 ### @section Common parameters
 ## Kubernetes version (using Helm capabilities if not set)

--- a/charts/testkube-operator/Chart.yaml
+++ b/charts/testkube-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: testkube-operator
 description: A Helm chart for the testkube-operator (installs needed CRDs only for now)
 type: application
-version: 1.17.8
+version: 1.17.9
 appVersion: 1.17.8
 dependencies:
   - name: global

--- a/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflows.yaml
+++ b/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflows.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.installCRD }}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -805,6 +806,187 @@ spec:
                       description: delay before the step
                       pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                       type: string
+                    distribute:
+                      description: run multiple pods with specification and wait until
+                        finish
+                      properties:
+                        container:
+                          description: container definition for simplicity
+                          x-kubernetes-preserve-unknown-fields: true
+                        count:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: static number of sharded instances to spawn
+                          x-kubernetes-int-or-string: true
+                        error:
+                          description: expression that determines if the pod initialization
+                            has failed
+                          type: string
+                        files:
+                          description: files to load into spawned pods
+                          items:
+                            properties:
+                              content:
+                                description: plain-text content to put inside
+                                type: string
+                              contentFrom:
+                                description: external source to use
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              mode:
+                                description: mode to use for the file
+                                format: int32
+                                type: integer
+                              path:
+                                description: path where the file should be accessible
+                                  at
+                                minLength: 1
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          type: array
+                        matrix:
+                          additionalProperties:
+                            items:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          description: matrix of parameters to spawn instances (static)
+                          type: object
+                        matrixExpressions:
+                          additionalProperties:
+                            type: string
+                          description: matrix of parameters to spawn instances (expressions)
+                          type: object
+                        maxCount:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: dynamic number of sharded instances to spawn
+                            - it will be lowered if there is not enough sharded values
+                          x-kubernetes-int-or-string: true
+                        parallelism:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: how many pods can be initializing at once
+                          x-kubernetes-int-or-string: true
+                        pod:
+                          description: pod template to spawn
+                          x-kubernetes-preserve-unknown-fields: true
+                        ready:
+                          description: expression that determines if the pod initialization
+                            has completed successfully
+                          type: string
+                        shardExpressions:
+                          additionalProperties:
+                            type: string
+                          description: parameters that should be distributed across
+                            sharded instances (expressions)
+                          type: object
+                        shards:
+                          additionalProperties:
+                            items:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          description: parameters that should be distributed across
+                            sharded instances (static)
+                          type: object
+                        timeout:
+                          description: how long we should wait for successful initialization
+                          pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
+                          type: string
+                      type: object
                     execute:
                       description: execute other Testkube resources
                       properties:
@@ -1282,6 +1464,190 @@ spec:
                           description: override default working directory in the image
                             (empty string to default WORKDIR for the image)
                           type: string
+                      type: object
+                    services:
+                      additionalProperties:
+                        properties:
+                          container:
+                            description: container definition for simplicity
+                            x-kubernetes-preserve-unknown-fields: true
+                          count:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: static number of sharded instances to spawn
+                            x-kubernetes-int-or-string: true
+                          error:
+                            description: expression that determines if the pod initialization
+                              has failed
+                            type: string
+                          files:
+                            description: files to load into spawned pods
+                            items:
+                              properties:
+                                content:
+                                  description: plain-text content to put inside
+                                  type: string
+                                contentFrom:
+                                  description: external source to use
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                mode:
+                                  description: mode to use for the file
+                                  format: int32
+                                  type: integer
+                                path:
+                                  description: path where the file should be accessible
+                                    at
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          matrix:
+                            additionalProperties:
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            description: matrix of parameters to spawn instances (static)
+                            type: object
+                          matrixExpressions:
+                            additionalProperties:
+                              type: string
+                            description: matrix of parameters to spawn instances (expressions)
+                            type: object
+                          maxCount:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: dynamic number of sharded instances to spawn
+                              - it will be lowered if there is not enough sharded
+                              values
+                            x-kubernetes-int-or-string: true
+                          parallelism:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: how many pods can be initializing at once
+                            x-kubernetes-int-or-string: true
+                          pod:
+                            description: pod template to spawn
+                            x-kubernetes-preserve-unknown-fields: true
+                          ready:
+                            description: expression that determines if the pod initialization
+                              has completed successfully
+                            type: string
+                          shardExpressions:
+                            additionalProperties:
+                              type: string
+                            description: parameters that should be distributed across
+                              sharded instances (expressions)
+                            type: object
+                          shards:
+                            additionalProperties:
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            description: parameters that should be distributed across
+                              sharded instances (static)
+                            type: object
+                          timeout:
+                            description: how long we should wait for successful initialization
+                            pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
+                            type: string
+                        type: object
+                      description: accompanying pods to create for the step
                       type: object
                     setup:
                       description: steps to run before other operations in this step
@@ -3763,6 +4129,188 @@ spec:
                       type: object
                     type: array
                 type: object
+              services:
+                additionalProperties:
+                  properties:
+                    container:
+                      description: container definition for simplicity
+                      x-kubernetes-preserve-unknown-fields: true
+                    count:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: static number of sharded instances to spawn
+                      x-kubernetes-int-or-string: true
+                    error:
+                      description: expression that determines if the pod initialization
+                        has failed
+                      type: string
+                    files:
+                      description: files to load into spawned pods
+                      items:
+                        properties:
+                          content:
+                            description: plain-text content to put inside
+                            type: string
+                          contentFrom:
+                            description: external source to use
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                  spec.serviceAccountName, status.hostIP, status.podIP,
+                                  status.podIPs.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          mode:
+                            description: mode to use for the file
+                            format: int32
+                            type: integer
+                          path:
+                            description: path where the file should be accessible
+                              at
+                            minLength: 1
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      type: array
+                    matrix:
+                      additionalProperties:
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      description: matrix of parameters to spawn instances (static)
+                      type: object
+                    matrixExpressions:
+                      additionalProperties:
+                        type: string
+                      description: matrix of parameters to spawn instances (expressions)
+                      type: object
+                    maxCount:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: dynamic number of sharded instances to spawn -
+                        it will be lowered if there is not enough sharded values
+                      x-kubernetes-int-or-string: true
+                    parallelism:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: how many pods can be initializing at once
+                      x-kubernetes-int-or-string: true
+                    pod:
+                      description: pod template to spawn
+                      x-kubernetes-preserve-unknown-fields: true
+                    ready:
+                      description: expression that determines if the pod initialization
+                        has completed successfully
+                      type: string
+                    shardExpressions:
+                      additionalProperties:
+                        type: string
+                      description: parameters that should be distributed across sharded
+                        instances (expressions)
+                      type: object
+                    shards:
+                      additionalProperties:
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      description: parameters that should be distributed across sharded
+                        instances (static)
+                      type: object
+                    timeout:
+                      description: how long we should wait for successful initialization
+                      pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
+                      type: string
+                  type: object
+                description: accompanying pods to create for the TestWorkflow
+                type: object
               setup:
                 description: steps for setting up the workflow
                 items:
@@ -4530,6 +5078,187 @@ spec:
                       description: delay before the step
                       pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                       type: string
+                    distribute:
+                      description: run multiple pods with specification and wait until
+                        finish
+                      properties:
+                        container:
+                          description: container definition for simplicity
+                          x-kubernetes-preserve-unknown-fields: true
+                        count:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: static number of sharded instances to spawn
+                          x-kubernetes-int-or-string: true
+                        error:
+                          description: expression that determines if the pod initialization
+                            has failed
+                          type: string
+                        files:
+                          description: files to load into spawned pods
+                          items:
+                            properties:
+                              content:
+                                description: plain-text content to put inside
+                                type: string
+                              contentFrom:
+                                description: external source to use
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              mode:
+                                description: mode to use for the file
+                                format: int32
+                                type: integer
+                              path:
+                                description: path where the file should be accessible
+                                  at
+                                minLength: 1
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          type: array
+                        matrix:
+                          additionalProperties:
+                            items:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          description: matrix of parameters to spawn instances (static)
+                          type: object
+                        matrixExpressions:
+                          additionalProperties:
+                            type: string
+                          description: matrix of parameters to spawn instances (expressions)
+                          type: object
+                        maxCount:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: dynamic number of sharded instances to spawn
+                            - it will be lowered if there is not enough sharded values
+                          x-kubernetes-int-or-string: true
+                        parallelism:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: how many pods can be initializing at once
+                          x-kubernetes-int-or-string: true
+                        pod:
+                          description: pod template to spawn
+                          x-kubernetes-preserve-unknown-fields: true
+                        ready:
+                          description: expression that determines if the pod initialization
+                            has completed successfully
+                          type: string
+                        shardExpressions:
+                          additionalProperties:
+                            type: string
+                          description: parameters that should be distributed across
+                            sharded instances (expressions)
+                          type: object
+                        shards:
+                          additionalProperties:
+                            items:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          description: parameters that should be distributed across
+                            sharded instances (static)
+                          type: object
+                        timeout:
+                          description: how long we should wait for successful initialization
+                          pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
+                          type: string
+                      type: object
                     execute:
                       description: execute other Testkube resources
                       properties:
@@ -5007,6 +5736,190 @@ spec:
                           description: override default working directory in the image
                             (empty string to default WORKDIR for the image)
                           type: string
+                      type: object
+                    services:
+                      additionalProperties:
+                        properties:
+                          container:
+                            description: container definition for simplicity
+                            x-kubernetes-preserve-unknown-fields: true
+                          count:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: static number of sharded instances to spawn
+                            x-kubernetes-int-or-string: true
+                          error:
+                            description: expression that determines if the pod initialization
+                              has failed
+                            type: string
+                          files:
+                            description: files to load into spawned pods
+                            items:
+                              properties:
+                                content:
+                                  description: plain-text content to put inside
+                                  type: string
+                                contentFrom:
+                                  description: external source to use
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                mode:
+                                  description: mode to use for the file
+                                  format: int32
+                                  type: integer
+                                path:
+                                  description: path where the file should be accessible
+                                    at
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          matrix:
+                            additionalProperties:
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            description: matrix of parameters to spawn instances (static)
+                            type: object
+                          matrixExpressions:
+                            additionalProperties:
+                              type: string
+                            description: matrix of parameters to spawn instances (expressions)
+                            type: object
+                          maxCount:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: dynamic number of sharded instances to spawn
+                              - it will be lowered if there is not enough sharded
+                              values
+                            x-kubernetes-int-or-string: true
+                          parallelism:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: how many pods can be initializing at once
+                            x-kubernetes-int-or-string: true
+                          pod:
+                            description: pod template to spawn
+                            x-kubernetes-preserve-unknown-fields: true
+                          ready:
+                            description: expression that determines if the pod initialization
+                              has completed successfully
+                            type: string
+                          shardExpressions:
+                            additionalProperties:
+                              type: string
+                            description: parameters that should be distributed across
+                              sharded instances (expressions)
+                            type: object
+                          shards:
+                            additionalProperties:
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            description: parameters that should be distributed across
+                              sharded instances (static)
+                            type: object
+                          timeout:
+                            description: how long we should wait for successful initialization
+                            pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
+                            type: string
+                        type: object
+                      description: accompanying pods to create for the step
                       type: object
                     setup:
                       description: steps to run before other operations in this step
@@ -5831,6 +6744,187 @@ spec:
                       description: delay before the step
                       pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                       type: string
+                    distribute:
+                      description: run multiple pods with specification and wait until
+                        finish
+                      properties:
+                        container:
+                          description: container definition for simplicity
+                          x-kubernetes-preserve-unknown-fields: true
+                        count:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: static number of sharded instances to spawn
+                          x-kubernetes-int-or-string: true
+                        error:
+                          description: expression that determines if the pod initialization
+                            has failed
+                          type: string
+                        files:
+                          description: files to load into spawned pods
+                          items:
+                            properties:
+                              content:
+                                description: plain-text content to put inside
+                                type: string
+                              contentFrom:
+                                description: external source to use
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              mode:
+                                description: mode to use for the file
+                                format: int32
+                                type: integer
+                              path:
+                                description: path where the file should be accessible
+                                  at
+                                minLength: 1
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          type: array
+                        matrix:
+                          additionalProperties:
+                            items:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          description: matrix of parameters to spawn instances (static)
+                          type: object
+                        matrixExpressions:
+                          additionalProperties:
+                            type: string
+                          description: matrix of parameters to spawn instances (expressions)
+                          type: object
+                        maxCount:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: dynamic number of sharded instances to spawn
+                            - it will be lowered if there is not enough sharded values
+                          x-kubernetes-int-or-string: true
+                        parallelism:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: how many pods can be initializing at once
+                          x-kubernetes-int-or-string: true
+                        pod:
+                          description: pod template to spawn
+                          x-kubernetes-preserve-unknown-fields: true
+                        ready:
+                          description: expression that determines if the pod initialization
+                            has completed successfully
+                          type: string
+                        shardExpressions:
+                          additionalProperties:
+                            type: string
+                          description: parameters that should be distributed across
+                            sharded instances (expressions)
+                          type: object
+                        shards:
+                          additionalProperties:
+                            items:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          description: parameters that should be distributed across
+                            sharded instances (static)
+                          type: object
+                        timeout:
+                          description: how long we should wait for successful initialization
+                          pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
+                          type: string
+                      type: object
                     execute:
                       description: execute other Testkube resources
                       properties:
@@ -6308,6 +7402,190 @@ spec:
                           description: override default working directory in the image
                             (empty string to default WORKDIR for the image)
                           type: string
+                      type: object
+                    services:
+                      additionalProperties:
+                        properties:
+                          container:
+                            description: container definition for simplicity
+                            x-kubernetes-preserve-unknown-fields: true
+                          count:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: static number of sharded instances to spawn
+                            x-kubernetes-int-or-string: true
+                          error:
+                            description: expression that determines if the pod initialization
+                              has failed
+                            type: string
+                          files:
+                            description: files to load into spawned pods
+                            items:
+                              properties:
+                                content:
+                                  description: plain-text content to put inside
+                                  type: string
+                                contentFrom:
+                                  description: external source to use
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                mode:
+                                  description: mode to use for the file
+                                  format: int32
+                                  type: integer
+                                path:
+                                  description: path where the file should be accessible
+                                    at
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          matrix:
+                            additionalProperties:
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            description: matrix of parameters to spawn instances (static)
+                            type: object
+                          matrixExpressions:
+                            additionalProperties:
+                              type: string
+                            description: matrix of parameters to spawn instances (expressions)
+                            type: object
+                          maxCount:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: dynamic number of sharded instances to spawn
+                              - it will be lowered if there is not enough sharded
+                              values
+                            x-kubernetes-int-or-string: true
+                          parallelism:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: how many pods can be initializing at once
+                            x-kubernetes-int-or-string: true
+                          pod:
+                            description: pod template to spawn
+                            x-kubernetes-preserve-unknown-fields: true
+                          ready:
+                            description: expression that determines if the pod initialization
+                              has completed successfully
+                            type: string
+                          shardExpressions:
+                            additionalProperties:
+                              type: string
+                            description: parameters that should be distributed across
+                              sharded instances (expressions)
+                            type: object
+                          shards:
+                            additionalProperties:
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            description: parameters that should be distributed across
+                              sharded instances (static)
+                            type: object
+                          timeout:
+                            description: how long we should wait for successful initialization
+                            pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
+                            type: string
+                        type: object
+                      description: accompanying pods to create for the step
                       type: object
                     setup:
                       description: steps to run before other operations in this step

--- a/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflows.yaml
+++ b/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflows.yaml
@@ -827,7 +827,7 @@ spec:
                             has failed
                           type: string
                         files:
-                          description: files to load into spawned pods
+                          description: static files to load into spawned pods
                           items:
                             properties:
                               content:
@@ -997,6 +997,28 @@ spec:
                           description: how long we should wait for successful initialization
                           pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                           type: string
+                        transfer:
+                          description: local files to transfer into spawned pods
+                          items:
+                            properties:
+                              files:
+                                description: file patterns to filter the files in
+                                  'from' path
+                                items:
+                                  type: string
+                                type: array
+                              from:
+                                description: dir path to fetch files from
+                                type: string
+                              mountPath:
+                                description: dir path to mount these files to
+                                type: string
+                            required:
+                            - files
+                            - from
+                            - mountPath
+                            type: object
+                          type: array
                       type: object
                     execute:
                       description: execute other Testkube resources
@@ -1496,7 +1518,7 @@ spec:
                               has failed
                             type: string
                           files:
-                            description: files to load into spawned pods
+                            description: static files to load into spawned pods
                             items:
                               properties:
                                 content:
@@ -1668,6 +1690,28 @@ spec:
                             description: how long we should wait for successful initialization
                             pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                             type: string
+                          transfer:
+                            description: local files to transfer into spawned pods
+                            items:
+                              properties:
+                                files:
+                                  description: file patterns to filter the files in
+                                    'from' path
+                                  items:
+                                    type: string
+                                  type: array
+                                from:
+                                  description: dir path to fetch files from
+                                  type: string
+                                mountPath:
+                                  description: dir path to mount these files to
+                                  type: string
+                              required:
+                              - files
+                              - from
+                              - mountPath
+                              type: object
+                            type: array
                         type: object
                       description: accompanying pods to create for the step
                       type: object
@@ -4171,7 +4215,7 @@ spec:
                         has failed
                       type: string
                     files:
-                      description: files to load into spawned pods
+                      description: static files to load into spawned pods
                       items:
                         properties:
                           content:
@@ -4341,6 +4385,28 @@ spec:
                       description: how long we should wait for successful initialization
                       pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                       type: string
+                    transfer:
+                      description: local files to transfer into spawned pods
+                      items:
+                        properties:
+                          files:
+                            description: file patterns to filter the files in 'from'
+                              path
+                            items:
+                              type: string
+                            type: array
+                          from:
+                            description: dir path to fetch files from
+                            type: string
+                          mountPath:
+                            description: dir path to mount these files to
+                            type: string
+                        required:
+                        - files
+                        - from
+                        - mountPath
+                        type: object
+                      type: array
                   type: object
                 description: accompanying pods to create for the TestWorkflow
                 type: object
@@ -5132,7 +5198,7 @@ spec:
                             has failed
                           type: string
                         files:
-                          description: files to load into spawned pods
+                          description: static files to load into spawned pods
                           items:
                             properties:
                               content:
@@ -5302,6 +5368,28 @@ spec:
                           description: how long we should wait for successful initialization
                           pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                           type: string
+                        transfer:
+                          description: local files to transfer into spawned pods
+                          items:
+                            properties:
+                              files:
+                                description: file patterns to filter the files in
+                                  'from' path
+                                items:
+                                  type: string
+                                type: array
+                              from:
+                                description: dir path to fetch files from
+                                type: string
+                              mountPath:
+                                description: dir path to mount these files to
+                                type: string
+                            required:
+                            - files
+                            - from
+                            - mountPath
+                            type: object
+                          type: array
                       type: object
                     execute:
                       description: execute other Testkube resources
@@ -5801,7 +5889,7 @@ spec:
                               has failed
                             type: string
                           files:
-                            description: files to load into spawned pods
+                            description: static files to load into spawned pods
                             items:
                               properties:
                                 content:
@@ -5973,6 +6061,28 @@ spec:
                             description: how long we should wait for successful initialization
                             pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                             type: string
+                          transfer:
+                            description: local files to transfer into spawned pods
+                            items:
+                              properties:
+                                files:
+                                  description: file patterns to filter the files in
+                                    'from' path
+                                  items:
+                                    type: string
+                                  type: array
+                                from:
+                                  description: dir path to fetch files from
+                                  type: string
+                                mountPath:
+                                  description: dir path to mount these files to
+                                  type: string
+                              required:
+                              - files
+                              - from
+                              - mountPath
+                              type: object
+                            type: array
                         type: object
                       description: accompanying pods to create for the step
                       type: object
@@ -6820,7 +6930,7 @@ spec:
                             has failed
                           type: string
                         files:
-                          description: files to load into spawned pods
+                          description: static files to load into spawned pods
                           items:
                             properties:
                               content:
@@ -6990,6 +7100,28 @@ spec:
                           description: how long we should wait for successful initialization
                           pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                           type: string
+                        transfer:
+                          description: local files to transfer into spawned pods
+                          items:
+                            properties:
+                              files:
+                                description: file patterns to filter the files in
+                                  'from' path
+                                items:
+                                  type: string
+                                type: array
+                              from:
+                                description: dir path to fetch files from
+                                type: string
+                              mountPath:
+                                description: dir path to mount these files to
+                                type: string
+                            required:
+                            - files
+                            - from
+                            - mountPath
+                            type: object
+                          type: array
                       type: object
                     execute:
                       description: execute other Testkube resources
@@ -7489,7 +7621,7 @@ spec:
                               has failed
                             type: string
                           files:
-                            description: files to load into spawned pods
+                            description: static files to load into spawned pods
                             items:
                               properties:
                                 content:
@@ -7661,6 +7793,28 @@ spec:
                             description: how long we should wait for successful initialization
                             pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                             type: string
+                          transfer:
+                            description: local files to transfer into spawned pods
+                            items:
+                              properties:
+                                files:
+                                  description: file patterns to filter the files in
+                                    'from' path
+                                  items:
+                                    type: string
+                                  type: array
+                                from:
+                                  description: dir path to fetch files from
+                                  type: string
+                                mountPath:
+                                  description: dir path to mount these files to
+                                  type: string
+                              required:
+                              - files
+                              - from
+                              - mountPath
+                              type: object
+                            type: array
                         type: object
                       description: accompanying pods to create for the step
                       type: object

--- a/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflows.yaml
+++ b/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflows.yaml
@@ -819,7 +819,7 @@ spec:
                           - type: string
                           description: static number of sharded instances to spawn
                           x-kubernetes-int-or-string: true
-                        displayName:
+                        description:
                           description: name to display in the interface
                           type: string
                         error:
@@ -1483,7 +1483,7 @@ spec:
                             - type: string
                             description: static number of sharded instances to spawn
                             x-kubernetes-int-or-string: true
-                          displayName:
+                          description:
                             description: name to display in the interface
                             type: string
                           error:
@@ -4153,7 +4153,7 @@ spec:
                       - type: string
                       description: static number of sharded instances to spawn
                       x-kubernetes-int-or-string: true
-                    displayName:
+                    description:
                       description: name to display in the interface
                       type: string
                     error:
@@ -5109,7 +5109,7 @@ spec:
                           - type: string
                           description: static number of sharded instances to spawn
                           x-kubernetes-int-or-string: true
-                        displayName:
+                        description:
                           description: name to display in the interface
                           type: string
                         error:
@@ -5773,7 +5773,7 @@ spec:
                             - type: string
                             description: static number of sharded instances to spawn
                             x-kubernetes-int-or-string: true
-                          displayName:
+                          description:
                             description: name to display in the interface
                             type: string
                           error:
@@ -6787,7 +6787,7 @@ spec:
                           - type: string
                           description: static number of sharded instances to spawn
                           x-kubernetes-int-or-string: true
-                        displayName:
+                        description:
                           description: name to display in the interface
                           type: string
                         error:
@@ -7451,7 +7451,7 @@ spec:
                             - type: string
                             description: static number of sharded instances to spawn
                             x-kubernetes-int-or-string: true
-                          displayName:
+                          description:
                             description: name to display in the interface
                             type: string
                           error:

--- a/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflows.yaml
+++ b/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflows.yaml
@@ -988,6 +988,11 @@ spec:
                           description: parameters that should be distributed across
                             sharded instances (static)
                           type: object
+                        strategy:
+                          description: configure common distribution strategy
+                          enum:
+                          - even
+                          type: string
                         timeout:
                           description: how long we should wait for successful initialization
                           pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
@@ -1654,6 +1659,11 @@ spec:
                             description: parameters that should be distributed across
                               sharded instances (static)
                             type: object
+                          strategy:
+                            description: configure common distribution strategy
+                            enum:
+                            - even
+                            type: string
                           timeout:
                             description: how long we should wait for successful initialization
                             pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
@@ -4322,6 +4332,11 @@ spec:
                       description: parameters that should be distributed across sharded
                         instances (static)
                       type: object
+                    strategy:
+                      description: configure common distribution strategy
+                      enum:
+                      - even
+                      type: string
                     timeout:
                       description: how long we should wait for successful initialization
                       pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
@@ -5278,6 +5293,11 @@ spec:
                           description: parameters that should be distributed across
                             sharded instances (static)
                           type: object
+                        strategy:
+                          description: configure common distribution strategy
+                          enum:
+                          - even
+                          type: string
                         timeout:
                           description: how long we should wait for successful initialization
                           pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
@@ -5944,6 +5964,11 @@ spec:
                             description: parameters that should be distributed across
                               sharded instances (static)
                             type: object
+                          strategy:
+                            description: configure common distribution strategy
+                            enum:
+                            - even
+                            type: string
                           timeout:
                             description: how long we should wait for successful initialization
                             pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
@@ -6956,6 +6981,11 @@ spec:
                           description: parameters that should be distributed across
                             sharded instances (static)
                           type: object
+                        strategy:
+                          description: configure common distribution strategy
+                          enum:
+                          - even
+                          type: string
                         timeout:
                           description: how long we should wait for successful initialization
                           pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
@@ -7622,6 +7652,11 @@ spec:
                             description: parameters that should be distributed across
                               sharded instances (static)
                             type: object
+                          strategy:
+                            description: configure common distribution strategy
+                            enum:
+                            - even
+                            type: string
                           timeout:
                             description: how long we should wait for successful initialization
                             pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$

--- a/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflows.yaml
+++ b/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflows.yaml
@@ -819,6 +819,9 @@ spec:
                           - type: string
                           description: static number of sharded instances to spawn
                           x-kubernetes-int-or-string: true
+                        displayName:
+                          description: name to display in the interface
+                          type: string
                         error:
                           description: expression that determines if the pod initialization
                             has failed
@@ -930,6 +933,9 @@ spec:
                             - path
                             type: object
                           type: array
+                        logs:
+                          description: should it fetch logs as artifact
+                          type: boolean
                         matrix:
                           additionalProperties:
                             items:
@@ -1477,6 +1483,9 @@ spec:
                             - type: string
                             description: static number of sharded instances to spawn
                             x-kubernetes-int-or-string: true
+                          displayName:
+                            description: name to display in the interface
+                            type: string
                           error:
                             description: expression that determines if the pod initialization
                               has failed
@@ -1589,6 +1598,9 @@ spec:
                               - path
                               type: object
                             type: array
+                          logs:
+                            description: should it fetch logs as artifact
+                            type: boolean
                           matrix:
                             additionalProperties:
                               items:
@@ -4141,6 +4153,9 @@ spec:
                       - type: string
                       description: static number of sharded instances to spawn
                       x-kubernetes-int-or-string: true
+                    displayName:
+                      description: name to display in the interface
+                      type: string
                     error:
                       description: expression that determines if the pod initialization
                         has failed
@@ -4252,6 +4267,9 @@ spec:
                         - path
                         type: object
                       type: array
+                    logs:
+                      description: should it fetch logs as artifact
+                      type: boolean
                     matrix:
                       additionalProperties:
                         items:
@@ -5091,6 +5109,9 @@ spec:
                           - type: string
                           description: static number of sharded instances to spawn
                           x-kubernetes-int-or-string: true
+                        displayName:
+                          description: name to display in the interface
+                          type: string
                         error:
                           description: expression that determines if the pod initialization
                             has failed
@@ -5202,6 +5223,9 @@ spec:
                             - path
                             type: object
                           type: array
+                        logs:
+                          description: should it fetch logs as artifact
+                          type: boolean
                         matrix:
                           additionalProperties:
                             items:
@@ -5749,6 +5773,9 @@ spec:
                             - type: string
                             description: static number of sharded instances to spawn
                             x-kubernetes-int-or-string: true
+                          displayName:
+                            description: name to display in the interface
+                            type: string
                           error:
                             description: expression that determines if the pod initialization
                               has failed
@@ -5861,6 +5888,9 @@ spec:
                               - path
                               type: object
                             type: array
+                          logs:
+                            description: should it fetch logs as artifact
+                            type: boolean
                           matrix:
                             additionalProperties:
                               items:
@@ -6757,6 +6787,9 @@ spec:
                           - type: string
                           description: static number of sharded instances to spawn
                           x-kubernetes-int-or-string: true
+                        displayName:
+                          description: name to display in the interface
+                          type: string
                         error:
                           description: expression that determines if the pod initialization
                             has failed
@@ -6868,6 +6901,9 @@ spec:
                             - path
                             type: object
                           type: array
+                        logs:
+                          description: should it fetch logs as artifact
+                          type: boolean
                         matrix:
                           additionalProperties:
                             items:
@@ -7415,6 +7451,9 @@ spec:
                             - type: string
                             description: static number of sharded instances to spawn
                             x-kubernetes-int-or-string: true
+                          displayName:
+                            description: name to display in the interface
+                            type: string
                           error:
                             description: expression that determines if the pod initialization
                               has failed
@@ -7527,6 +7566,9 @@ spec:
                               - path
                               type: object
                             type: array
+                          logs:
+                            description: should it fetch logs as artifact
+                            type: boolean
                           matrix:
                             additionalProperties:
                               items:

--- a/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflowtemplates.yaml
+++ b/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflowtemplates.yaml
@@ -988,6 +988,11 @@ spec:
                           description: parameters that should be distributed across
                             sharded instances (static)
                           type: object
+                        strategy:
+                          description: configure common distribution strategy
+                          enum:
+                          - even
+                          type: string
                         timeout:
                           description: how long we should wait for successful initialization
                           pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
@@ -1654,6 +1659,11 @@ spec:
                             description: parameters that should be distributed across
                               sharded instances (static)
                             type: object
+                          strategy:
+                            description: configure common distribution strategy
+                            enum:
+                            - even
+                            type: string
                           timeout:
                             description: how long we should wait for successful initialization
                             pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
@@ -4284,6 +4294,11 @@ spec:
                       description: parameters that should be distributed across sharded
                         instances (static)
                       type: object
+                    strategy:
+                      description: configure common distribution strategy
+                      enum:
+                      - even
+                      type: string
                     timeout:
                       description: how long we should wait for successful initialization
                       pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
@@ -5240,6 +5255,11 @@ spec:
                           description: parameters that should be distributed across
                             sharded instances (static)
                           type: object
+                        strategy:
+                          description: configure common distribution strategy
+                          enum:
+                          - even
+                          type: string
                         timeout:
                           description: how long we should wait for successful initialization
                           pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
@@ -5906,6 +5926,11 @@ spec:
                             description: parameters that should be distributed across
                               sharded instances (static)
                             type: object
+                          strategy:
+                            description: configure common distribution strategy
+                            enum:
+                            - even
+                            type: string
                           timeout:
                             description: how long we should wait for successful initialization
                             pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
@@ -6880,6 +6905,11 @@ spec:
                           description: parameters that should be distributed across
                             sharded instances (static)
                           type: object
+                        strategy:
+                          description: configure common distribution strategy
+                          enum:
+                          - even
+                          type: string
                         timeout:
                           description: how long we should wait for successful initialization
                           pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
@@ -7546,6 +7576,11 @@ spec:
                             description: parameters that should be distributed across
                               sharded instances (static)
                             type: object
+                          strategy:
+                            description: configure common distribution strategy
+                            enum:
+                            - even
+                            type: string
                           timeout:
                             description: how long we should wait for successful initialization
                             pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$

--- a/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflowtemplates.yaml
+++ b/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflowtemplates.yaml
@@ -819,7 +819,7 @@ spec:
                           - type: string
                           description: static number of sharded instances to spawn
                           x-kubernetes-int-or-string: true
-                        displayName:
+                        description:
                           description: name to display in the interface
                           type: string
                         error:
@@ -1483,7 +1483,7 @@ spec:
                             - type: string
                             description: static number of sharded instances to spawn
                             x-kubernetes-int-or-string: true
-                          displayName:
+                          description:
                             description: name to display in the interface
                             type: string
                           error:
@@ -4115,7 +4115,7 @@ spec:
                       - type: string
                       description: static number of sharded instances to spawn
                       x-kubernetes-int-or-string: true
-                    displayName:
+                    description:
                       description: name to display in the interface
                       type: string
                     error:
@@ -5071,7 +5071,7 @@ spec:
                           - type: string
                           description: static number of sharded instances to spawn
                           x-kubernetes-int-or-string: true
-                        displayName:
+                        description:
                           description: name to display in the interface
                           type: string
                         error:
@@ -5735,7 +5735,7 @@ spec:
                             - type: string
                             description: static number of sharded instances to spawn
                             x-kubernetes-int-or-string: true
-                          displayName:
+                          description:
                             description: name to display in the interface
                             type: string
                           error:
@@ -6711,7 +6711,7 @@ spec:
                           - type: string
                           description: static number of sharded instances to spawn
                           x-kubernetes-int-or-string: true
-                        displayName:
+                        description:
                           description: name to display in the interface
                           type: string
                         error:
@@ -7375,7 +7375,7 @@ spec:
                             - type: string
                             description: static number of sharded instances to spawn
                             x-kubernetes-int-or-string: true
-                          displayName:
+                          description:
                             description: name to display in the interface
                             type: string
                           error:

--- a/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflowtemplates.yaml
+++ b/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflowtemplates.yaml
@@ -806,6 +806,187 @@ spec:
                       description: delay before the step
                       pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                       type: string
+                    distribute:
+                      description: run multiple pods with specification and wait until
+                        finish
+                      properties:
+                        container:
+                          description: container definition for simplicity
+                          x-kubernetes-preserve-unknown-fields: true
+                        count:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: static number of sharded instances to spawn
+                          x-kubernetes-int-or-string: true
+                        error:
+                          description: expression that determines if the pod initialization
+                            has failed
+                          type: string
+                        files:
+                          description: files to load into spawned pods
+                          items:
+                            properties:
+                              content:
+                                description: plain-text content to put inside
+                                type: string
+                              contentFrom:
+                                description: external source to use
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              mode:
+                                description: mode to use for the file
+                                format: int32
+                                type: integer
+                              path:
+                                description: path where the file should be accessible
+                                  at
+                                minLength: 1
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          type: array
+                        matrix:
+                          additionalProperties:
+                            items:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          description: matrix of parameters to spawn instances (static)
+                          type: object
+                        matrixExpressions:
+                          additionalProperties:
+                            type: string
+                          description: matrix of parameters to spawn instances (expressions)
+                          type: object
+                        maxCount:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: dynamic number of sharded instances to spawn
+                            - it will be lowered if there is not enough sharded values
+                          x-kubernetes-int-or-string: true
+                        parallelism:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: how many pods can be initializing at once
+                          x-kubernetes-int-or-string: true
+                        pod:
+                          description: pod template to spawn
+                          x-kubernetes-preserve-unknown-fields: true
+                        ready:
+                          description: expression that determines if the pod initialization
+                            has completed successfully
+                          type: string
+                        shardExpressions:
+                          additionalProperties:
+                            type: string
+                          description: parameters that should be distributed across
+                            sharded instances (expressions)
+                          type: object
+                        shards:
+                          additionalProperties:
+                            items:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          description: parameters that should be distributed across
+                            sharded instances (static)
+                          type: object
+                        timeout:
+                          description: how long we should wait for successful initialization
+                          pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
+                          type: string
+                      type: object
                     execute:
                       description: execute other Testkube resources
                       properties:
@@ -1283,6 +1464,190 @@ spec:
                           description: override default working directory in the image
                             (empty string to default WORKDIR for the image)
                           type: string
+                      type: object
+                    services:
+                      additionalProperties:
+                        properties:
+                          container:
+                            description: container definition for simplicity
+                            x-kubernetes-preserve-unknown-fields: true
+                          count:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: static number of sharded instances to spawn
+                            x-kubernetes-int-or-string: true
+                          error:
+                            description: expression that determines if the pod initialization
+                              has failed
+                            type: string
+                          files:
+                            description: files to load into spawned pods
+                            items:
+                              properties:
+                                content:
+                                  description: plain-text content to put inside
+                                  type: string
+                                contentFrom:
+                                  description: external source to use
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                mode:
+                                  description: mode to use for the file
+                                  format: int32
+                                  type: integer
+                                path:
+                                  description: path where the file should be accessible
+                                    at
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          matrix:
+                            additionalProperties:
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            description: matrix of parameters to spawn instances (static)
+                            type: object
+                          matrixExpressions:
+                            additionalProperties:
+                              type: string
+                            description: matrix of parameters to spawn instances (expressions)
+                            type: object
+                          maxCount:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: dynamic number of sharded instances to spawn
+                              - it will be lowered if there is not enough sharded
+                              values
+                            x-kubernetes-int-or-string: true
+                          parallelism:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: how many pods can be initializing at once
+                            x-kubernetes-int-or-string: true
+                          pod:
+                            description: pod template to spawn
+                            x-kubernetes-preserve-unknown-fields: true
+                          ready:
+                            description: expression that determines if the pod initialization
+                              has completed successfully
+                            type: string
+                          shardExpressions:
+                            additionalProperties:
+                              type: string
+                            description: parameters that should be distributed across
+                              sharded instances (expressions)
+                            type: object
+                          shards:
+                            additionalProperties:
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            description: parameters that should be distributed across
+                              sharded instances (static)
+                            type: object
+                          timeout:
+                            description: how long we should wait for successful initialization
+                            pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
+                            type: string
+                        type: object
+                      description: accompanying pods to create for the step
                       type: object
                     setup:
                       description: steps to run before other operations in this step
@@ -3726,6 +4091,188 @@ spec:
                       type: object
                     type: array
                 type: object
+              services:
+                additionalProperties:
+                  properties:
+                    container:
+                      description: container definition for simplicity
+                      x-kubernetes-preserve-unknown-fields: true
+                    count:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: static number of sharded instances to spawn
+                      x-kubernetes-int-or-string: true
+                    error:
+                      description: expression that determines if the pod initialization
+                        has failed
+                      type: string
+                    files:
+                      description: files to load into spawned pods
+                      items:
+                        properties:
+                          content:
+                            description: plain-text content to put inside
+                            type: string
+                          contentFrom:
+                            description: external source to use
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                  spec.serviceAccountName, status.hostIP, status.podIP,
+                                  status.podIPs.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          mode:
+                            description: mode to use for the file
+                            format: int32
+                            type: integer
+                          path:
+                            description: path where the file should be accessible
+                              at
+                            minLength: 1
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      type: array
+                    matrix:
+                      additionalProperties:
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      description: matrix of parameters to spawn instances (static)
+                      type: object
+                    matrixExpressions:
+                      additionalProperties:
+                        type: string
+                      description: matrix of parameters to spawn instances (expressions)
+                      type: object
+                    maxCount:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: dynamic number of sharded instances to spawn -
+                        it will be lowered if there is not enough sharded values
+                      x-kubernetes-int-or-string: true
+                    parallelism:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: how many pods can be initializing at once
+                      x-kubernetes-int-or-string: true
+                    pod:
+                      description: pod template to spawn
+                      x-kubernetes-preserve-unknown-fields: true
+                    ready:
+                      description: expression that determines if the pod initialization
+                        has completed successfully
+                      type: string
+                    shardExpressions:
+                      additionalProperties:
+                        type: string
+                      description: parameters that should be distributed across sharded
+                        instances (expressions)
+                      type: object
+                    shards:
+                      additionalProperties:
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      description: parameters that should be distributed across sharded
+                        instances (static)
+                      type: object
+                    timeout:
+                      description: how long we should wait for successful initialization
+                      pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
+                      type: string
+                  type: object
+                description: accompanying pods to create for the TestWorkflow
+                type: object
               setup:
                 description: steps for setting up the workflow
                 items:
@@ -4493,6 +5040,187 @@ spec:
                       description: delay before the step
                       pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                       type: string
+                    distribute:
+                      description: run multiple pods with specification and wait until
+                        finish
+                      properties:
+                        container:
+                          description: container definition for simplicity
+                          x-kubernetes-preserve-unknown-fields: true
+                        count:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: static number of sharded instances to spawn
+                          x-kubernetes-int-or-string: true
+                        error:
+                          description: expression that determines if the pod initialization
+                            has failed
+                          type: string
+                        files:
+                          description: files to load into spawned pods
+                          items:
+                            properties:
+                              content:
+                                description: plain-text content to put inside
+                                type: string
+                              contentFrom:
+                                description: external source to use
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              mode:
+                                description: mode to use for the file
+                                format: int32
+                                type: integer
+                              path:
+                                description: path where the file should be accessible
+                                  at
+                                minLength: 1
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          type: array
+                        matrix:
+                          additionalProperties:
+                            items:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          description: matrix of parameters to spawn instances (static)
+                          type: object
+                        matrixExpressions:
+                          additionalProperties:
+                            type: string
+                          description: matrix of parameters to spawn instances (expressions)
+                          type: object
+                        maxCount:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: dynamic number of sharded instances to spawn
+                            - it will be lowered if there is not enough sharded values
+                          x-kubernetes-int-or-string: true
+                        parallelism:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: how many pods can be initializing at once
+                          x-kubernetes-int-or-string: true
+                        pod:
+                          description: pod template to spawn
+                          x-kubernetes-preserve-unknown-fields: true
+                        ready:
+                          description: expression that determines if the pod initialization
+                            has completed successfully
+                          type: string
+                        shardExpressions:
+                          additionalProperties:
+                            type: string
+                          description: parameters that should be distributed across
+                            sharded instances (expressions)
+                          type: object
+                        shards:
+                          additionalProperties:
+                            items:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          description: parameters that should be distributed across
+                            sharded instances (static)
+                          type: object
+                        timeout:
+                          description: how long we should wait for successful initialization
+                          pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
+                          type: string
+                      type: object
                     execute:
                       description: execute other Testkube resources
                       properties:
@@ -4970,6 +5698,190 @@ spec:
                           description: override default working directory in the image
                             (empty string to default WORKDIR for the image)
                           type: string
+                      type: object
+                    services:
+                      additionalProperties:
+                        properties:
+                          container:
+                            description: container definition for simplicity
+                            x-kubernetes-preserve-unknown-fields: true
+                          count:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: static number of sharded instances to spawn
+                            x-kubernetes-int-or-string: true
+                          error:
+                            description: expression that determines if the pod initialization
+                              has failed
+                            type: string
+                          files:
+                            description: files to load into spawned pods
+                            items:
+                              properties:
+                                content:
+                                  description: plain-text content to put inside
+                                  type: string
+                                contentFrom:
+                                  description: external source to use
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                mode:
+                                  description: mode to use for the file
+                                  format: int32
+                                  type: integer
+                                path:
+                                  description: path where the file should be accessible
+                                    at
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          matrix:
+                            additionalProperties:
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            description: matrix of parameters to spawn instances (static)
+                            type: object
+                          matrixExpressions:
+                            additionalProperties:
+                              type: string
+                            description: matrix of parameters to spawn instances (expressions)
+                            type: object
+                          maxCount:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: dynamic number of sharded instances to spawn
+                              - it will be lowered if there is not enough sharded
+                              values
+                            x-kubernetes-int-or-string: true
+                          parallelism:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: how many pods can be initializing at once
+                            x-kubernetes-int-or-string: true
+                          pod:
+                            description: pod template to spawn
+                            x-kubernetes-preserve-unknown-fields: true
+                          ready:
+                            description: expression that determines if the pod initialization
+                              has completed successfully
+                            type: string
+                          shardExpressions:
+                            additionalProperties:
+                              type: string
+                            description: parameters that should be distributed across
+                              sharded instances (expressions)
+                            type: object
+                          shards:
+                            additionalProperties:
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            description: parameters that should be distributed across
+                              sharded instances (static)
+                            type: object
+                          timeout:
+                            description: how long we should wait for successful initialization
+                            pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
+                            type: string
+                        type: object
+                      description: accompanying pods to create for the step
                       type: object
                     setup:
                       description: steps to run before other operations in this step
@@ -5756,6 +6668,187 @@ spec:
                       description: delay before the step
                       pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                       type: string
+                    distribute:
+                      description: run multiple pods with specification and wait until
+                        finish
+                      properties:
+                        container:
+                          description: container definition for simplicity
+                          x-kubernetes-preserve-unknown-fields: true
+                        count:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: static number of sharded instances to spawn
+                          x-kubernetes-int-or-string: true
+                        error:
+                          description: expression that determines if the pod initialization
+                            has failed
+                          type: string
+                        files:
+                          description: files to load into spawned pods
+                          items:
+                            properties:
+                              content:
+                                description: plain-text content to put inside
+                                type: string
+                              contentFrom:
+                                description: external source to use
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              mode:
+                                description: mode to use for the file
+                                format: int32
+                                type: integer
+                              path:
+                                description: path where the file should be accessible
+                                  at
+                                minLength: 1
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          type: array
+                        matrix:
+                          additionalProperties:
+                            items:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          description: matrix of parameters to spawn instances (static)
+                          type: object
+                        matrixExpressions:
+                          additionalProperties:
+                            type: string
+                          description: matrix of parameters to spawn instances (expressions)
+                          type: object
+                        maxCount:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: dynamic number of sharded instances to spawn
+                            - it will be lowered if there is not enough sharded values
+                          x-kubernetes-int-or-string: true
+                        parallelism:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: how many pods can be initializing at once
+                          x-kubernetes-int-or-string: true
+                        pod:
+                          description: pod template to spawn
+                          x-kubernetes-preserve-unknown-fields: true
+                        ready:
+                          description: expression that determines if the pod initialization
+                            has completed successfully
+                          type: string
+                        shardExpressions:
+                          additionalProperties:
+                            type: string
+                          description: parameters that should be distributed across
+                            sharded instances (expressions)
+                          type: object
+                        shards:
+                          additionalProperties:
+                            items:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          description: parameters that should be distributed across
+                            sharded instances (static)
+                          type: object
+                        timeout:
+                          description: how long we should wait for successful initialization
+                          pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
+                          type: string
+                      type: object
                     execute:
                       description: execute other Testkube resources
                       properties:
@@ -6233,6 +7326,190 @@ spec:
                           description: override default working directory in the image
                             (empty string to default WORKDIR for the image)
                           type: string
+                      type: object
+                    services:
+                      additionalProperties:
+                        properties:
+                          container:
+                            description: container definition for simplicity
+                            x-kubernetes-preserve-unknown-fields: true
+                          count:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: static number of sharded instances to spawn
+                            x-kubernetes-int-or-string: true
+                          error:
+                            description: expression that determines if the pod initialization
+                              has failed
+                            type: string
+                          files:
+                            description: files to load into spawned pods
+                            items:
+                              properties:
+                                content:
+                                  description: plain-text content to put inside
+                                  type: string
+                                contentFrom:
+                                  description: external source to use
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                mode:
+                                  description: mode to use for the file
+                                  format: int32
+                                  type: integer
+                                path:
+                                  description: path where the file should be accessible
+                                    at
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          matrix:
+                            additionalProperties:
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            description: matrix of parameters to spawn instances (static)
+                            type: object
+                          matrixExpressions:
+                            additionalProperties:
+                              type: string
+                            description: matrix of parameters to spawn instances (expressions)
+                            type: object
+                          maxCount:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: dynamic number of sharded instances to spawn
+                              - it will be lowered if there is not enough sharded
+                              values
+                            x-kubernetes-int-or-string: true
+                          parallelism:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: how many pods can be initializing at once
+                            x-kubernetes-int-or-string: true
+                          pod:
+                            description: pod template to spawn
+                            x-kubernetes-preserve-unknown-fields: true
+                          ready:
+                            description: expression that determines if the pod initialization
+                              has completed successfully
+                            type: string
+                          shardExpressions:
+                            additionalProperties:
+                              type: string
+                            description: parameters that should be distributed across
+                              sharded instances (expressions)
+                            type: object
+                          shards:
+                            additionalProperties:
+                              items:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              type: array
+                            description: parameters that should be distributed across
+                              sharded instances (static)
+                            type: object
+                          timeout:
+                            description: how long we should wait for successful initialization
+                            pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
+                            type: string
+                        type: object
+                      description: accompanying pods to create for the step
                       type: object
                     setup:
                       description: steps to run before other operations in this step

--- a/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflowtemplates.yaml
+++ b/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflowtemplates.yaml
@@ -819,6 +819,9 @@ spec:
                           - type: string
                           description: static number of sharded instances to spawn
                           x-kubernetes-int-or-string: true
+                        displayName:
+                          description: name to display in the interface
+                          type: string
                         error:
                           description: expression that determines if the pod initialization
                             has failed
@@ -930,6 +933,9 @@ spec:
                             - path
                             type: object
                           type: array
+                        logs:
+                          description: should it fetch logs as artifact
+                          type: boolean
                         matrix:
                           additionalProperties:
                             items:
@@ -1477,6 +1483,9 @@ spec:
                             - type: string
                             description: static number of sharded instances to spawn
                             x-kubernetes-int-or-string: true
+                          displayName:
+                            description: name to display in the interface
+                            type: string
                           error:
                             description: expression that determines if the pod initialization
                               has failed
@@ -1589,6 +1598,9 @@ spec:
                               - path
                               type: object
                             type: array
+                          logs:
+                            description: should it fetch logs as artifact
+                            type: boolean
                           matrix:
                             additionalProperties:
                               items:
@@ -4103,6 +4115,9 @@ spec:
                       - type: string
                       description: static number of sharded instances to spawn
                       x-kubernetes-int-or-string: true
+                    displayName:
+                      description: name to display in the interface
+                      type: string
                     error:
                       description: expression that determines if the pod initialization
                         has failed
@@ -4214,6 +4229,9 @@ spec:
                         - path
                         type: object
                       type: array
+                    logs:
+                      description: should it fetch logs as artifact
+                      type: boolean
                     matrix:
                       additionalProperties:
                         items:
@@ -5053,6 +5071,9 @@ spec:
                           - type: string
                           description: static number of sharded instances to spawn
                           x-kubernetes-int-or-string: true
+                        displayName:
+                          description: name to display in the interface
+                          type: string
                         error:
                           description: expression that determines if the pod initialization
                             has failed
@@ -5164,6 +5185,9 @@ spec:
                             - path
                             type: object
                           type: array
+                        logs:
+                          description: should it fetch logs as artifact
+                          type: boolean
                         matrix:
                           additionalProperties:
                             items:
@@ -5711,6 +5735,9 @@ spec:
                             - type: string
                             description: static number of sharded instances to spawn
                             x-kubernetes-int-or-string: true
+                          displayName:
+                            description: name to display in the interface
+                            type: string
                           error:
                             description: expression that determines if the pod initialization
                               has failed
@@ -5823,6 +5850,9 @@ spec:
                               - path
                               type: object
                             type: array
+                          logs:
+                            description: should it fetch logs as artifact
+                            type: boolean
                           matrix:
                             additionalProperties:
                               items:
@@ -6681,6 +6711,9 @@ spec:
                           - type: string
                           description: static number of sharded instances to spawn
                           x-kubernetes-int-or-string: true
+                        displayName:
+                          description: name to display in the interface
+                          type: string
                         error:
                           description: expression that determines if the pod initialization
                             has failed
@@ -6792,6 +6825,9 @@ spec:
                             - path
                             type: object
                           type: array
+                        logs:
+                          description: should it fetch logs as artifact
+                          type: boolean
                         matrix:
                           additionalProperties:
                             items:
@@ -7339,6 +7375,9 @@ spec:
                             - type: string
                             description: static number of sharded instances to spawn
                             x-kubernetes-int-or-string: true
+                          displayName:
+                            description: name to display in the interface
+                            type: string
                           error:
                             description: expression that determines if the pod initialization
                               has failed
@@ -7451,6 +7490,9 @@ spec:
                               - path
                               type: object
                             type: array
+                          logs:
+                            description: should it fetch logs as artifact
+                            type: boolean
                           matrix:
                             additionalProperties:
                               items:

--- a/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflowtemplates.yaml
+++ b/charts/testkube-operator/templates/testworkflows.testkube.io_testworkflowtemplates.yaml
@@ -827,7 +827,7 @@ spec:
                             has failed
                           type: string
                         files:
-                          description: files to load into spawned pods
+                          description: static files to load into spawned pods
                           items:
                             properties:
                               content:
@@ -997,6 +997,28 @@ spec:
                           description: how long we should wait for successful initialization
                           pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                           type: string
+                        transfer:
+                          description: local files to transfer into spawned pods
+                          items:
+                            properties:
+                              files:
+                                description: file patterns to filter the files in
+                                  'from' path
+                                items:
+                                  type: string
+                                type: array
+                              from:
+                                description: dir path to fetch files from
+                                type: string
+                              mountPath:
+                                description: dir path to mount these files to
+                                type: string
+                            required:
+                            - files
+                            - from
+                            - mountPath
+                            type: object
+                          type: array
                       type: object
                     execute:
                       description: execute other Testkube resources
@@ -1496,7 +1518,7 @@ spec:
                               has failed
                             type: string
                           files:
-                            description: files to load into spawned pods
+                            description: static files to load into spawned pods
                             items:
                               properties:
                                 content:
@@ -1668,6 +1690,28 @@ spec:
                             description: how long we should wait for successful initialization
                             pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                             type: string
+                          transfer:
+                            description: local files to transfer into spawned pods
+                            items:
+                              properties:
+                                files:
+                                  description: file patterns to filter the files in
+                                    'from' path
+                                  items:
+                                    type: string
+                                  type: array
+                                from:
+                                  description: dir path to fetch files from
+                                  type: string
+                                mountPath:
+                                  description: dir path to mount these files to
+                                  type: string
+                              required:
+                              - files
+                              - from
+                              - mountPath
+                              type: object
+                            type: array
                         type: object
                       description: accompanying pods to create for the step
                       type: object
@@ -4133,7 +4177,7 @@ spec:
                         has failed
                       type: string
                     files:
-                      description: files to load into spawned pods
+                      description: static files to load into spawned pods
                       items:
                         properties:
                           content:
@@ -4303,6 +4347,28 @@ spec:
                       description: how long we should wait for successful initialization
                       pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                       type: string
+                    transfer:
+                      description: local files to transfer into spawned pods
+                      items:
+                        properties:
+                          files:
+                            description: file patterns to filter the files in 'from'
+                              path
+                            items:
+                              type: string
+                            type: array
+                          from:
+                            description: dir path to fetch files from
+                            type: string
+                          mountPath:
+                            description: dir path to mount these files to
+                            type: string
+                        required:
+                        - files
+                        - from
+                        - mountPath
+                        type: object
+                      type: array
                   type: object
                 description: accompanying pods to create for the TestWorkflow
                 type: object
@@ -5094,7 +5160,7 @@ spec:
                             has failed
                           type: string
                         files:
-                          description: files to load into spawned pods
+                          description: static files to load into spawned pods
                           items:
                             properties:
                               content:
@@ -5264,6 +5330,28 @@ spec:
                           description: how long we should wait for successful initialization
                           pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                           type: string
+                        transfer:
+                          description: local files to transfer into spawned pods
+                          items:
+                            properties:
+                              files:
+                                description: file patterns to filter the files in
+                                  'from' path
+                                items:
+                                  type: string
+                                type: array
+                              from:
+                                description: dir path to fetch files from
+                                type: string
+                              mountPath:
+                                description: dir path to mount these files to
+                                type: string
+                            required:
+                            - files
+                            - from
+                            - mountPath
+                            type: object
+                          type: array
                       type: object
                     execute:
                       description: execute other Testkube resources
@@ -5763,7 +5851,7 @@ spec:
                               has failed
                             type: string
                           files:
-                            description: files to load into spawned pods
+                            description: static files to load into spawned pods
                             items:
                               properties:
                                 content:
@@ -5935,6 +6023,28 @@ spec:
                             description: how long we should wait for successful initialization
                             pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                             type: string
+                          transfer:
+                            description: local files to transfer into spawned pods
+                            items:
+                              properties:
+                                files:
+                                  description: file patterns to filter the files in
+                                    'from' path
+                                  items:
+                                    type: string
+                                  type: array
+                                from:
+                                  description: dir path to fetch files from
+                                  type: string
+                                mountPath:
+                                  description: dir path to mount these files to
+                                  type: string
+                              required:
+                              - files
+                              - from
+                              - mountPath
+                              type: object
+                            type: array
                         type: object
                       description: accompanying pods to create for the step
                       type: object
@@ -6744,7 +6854,7 @@ spec:
                             has failed
                           type: string
                         files:
-                          description: files to load into spawned pods
+                          description: static files to load into spawned pods
                           items:
                             properties:
                               content:
@@ -6914,6 +7024,28 @@ spec:
                           description: how long we should wait for successful initialization
                           pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                           type: string
+                        transfer:
+                          description: local files to transfer into spawned pods
+                          items:
+                            properties:
+                              files:
+                                description: file patterns to filter the files in
+                                  'from' path
+                                items:
+                                  type: string
+                                type: array
+                              from:
+                                description: dir path to fetch files from
+                                type: string
+                              mountPath:
+                                description: dir path to mount these files to
+                                type: string
+                            required:
+                            - files
+                            - from
+                            - mountPath
+                            type: object
+                          type: array
                       type: object
                     execute:
                       description: execute other Testkube resources
@@ -7413,7 +7545,7 @@ spec:
                               has failed
                             type: string
                           files:
-                            description: files to load into spawned pods
+                            description: static files to load into spawned pods
                             items:
                               properties:
                                 content:
@@ -7585,6 +7717,28 @@ spec:
                             description: how long we should wait for successful initialization
                             pattern: ^((0|[1-9][0-9]*)h)?((0|[1-9][0-9]*)m)?((0|[1-9][0-9]*)s)?((0|[1-9][0-9]*)ms)?$
                             type: string
+                          transfer:
+                            description: local files to transfer into spawned pods
+                            items:
+                              properties:
+                                files:
+                                  description: file patterns to filter the files in
+                                    'from' path
+                                  items:
+                                    type: string
+                                  type: array
+                                from:
+                                  description: dir path to fetch files from
+                                  type: string
+                                mountPath:
+                                  description: dir path to mount these files to
+                                  type: string
+                              required:
+                              - files
+                              - from
+                              - mountPath
+                              type: object
+                            type: array
                         type: object
                       description: accompanying pods to create for the step
                       type: object

--- a/charts/testkube/Chart.yaml
+++ b/charts/testkube/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 1.17.16
 dependencies:
   - name: testkube-operator
-    version: 1.17.8
+    version: 1.17.9
     #repository: https://kubeshop.github.io/helm-charts
     repository: "file://../testkube-operator"
     condition: testkube-operator.enabled
@@ -18,7 +18,7 @@ dependencies:
     version: 1.1.7
     repository: https://nats-io.github.io/k8s/helm/charts/
   - name: testkube-api
-    version: 1.17.10
+    version: 1.17.11
     #repository: https://kubeshop.github.io/helm-charts
     repository: "file://../testkube-api"
   - name: testkube-logs

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -26,6 +26,10 @@ global:
   # -- Features map for the whole chart
   features:
     logsV2: false
+  # -- Test Workflows configuration
+  testWorkflows:
+    # -- Create headless service for assisting pods
+    createAssistingPodsService: true
 
 # -- MongoDB pre-upgrade parameters
 preUpgradeHook:

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -30,6 +30,8 @@ global:
   testWorkflows:
     # -- Create headless service for assisting pods
     createAssistingPodsService: true
+    # -- Create TestWorkflowTemplates to easily use the service account
+    createServiceAccountTemplates: true
 
 # -- MongoDB pre-upgrade parameters
 preUpgradeHook:


### PR DESCRIPTION
## Pull request description 

* Add headless service for resolving `host` of accompanying services in TestWorkflows
* Add default built-in `TestWorkflowTemplate` for using Testkube API Server's service account (`serviceaccount/fullaccess`)

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Fixes

- https://linear.app/kubeshop/issue/TKC-1763/[epic]-testworkflows-distributed-tests-parallelisation