### PR TITLE
chore: template url values

### DIFF
--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -305,15 +305,15 @@ spec:
             {{- end}}
             {{- if .Values.cloud.url }}
             - name: TESTKUBE_CLOUD_URL
-              value:  "{{ .Values.cloud.url }}"
+              value:  {{ tpl .Values.cloud.url $ | quote }}
             - name: TESTKUBE_PRO_URL
-              value:  "{{ .Values.cloud.url }}"
+              value:  {{ tpl .Values.cloud.url $ | quote }}
             {{- end }}
             {{- if .Values.cloud.uiUrl}}
             - name: TESTKUBE_CLOUD_UI_URL
-              value: "{{ .Values.cloud.uiUrl }}"
+              value: {{ tpl .Values.cloud.uiUrl $ | quote }}
             - name: TESTKUBE_PRO_UI_URL
-              value: "{{ .Values.cloud.uiUrl }}"
+              value: {{ tpl .Values.cloud.uiUrl $ | quote }}
             {{- end}}
             {{- if not .Values.cloud.tls.enabled }}
             - name: TESTKUBE_PRO_TLS_INSECURE


### PR DESCRIPTION
## Pull request description 

It allows defining values.yaml that can be installed in arbitrary namespaces without reconfiguration.

```
url: testkube-enterprise-api.{{.Release.Namespace}}.svc.cluster.local:8089
``` 


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-