### PR TITLE
fix: pull from git server with private-ca certs

### DIFF
--- a/charts/testkube-api/job-container-template.yml.tmpl
+++ b/charts/testkube-api/job-container-template.yml.tmpl
@@ -21,6 +21,13 @@ spec:
         command:
           - "/bin/runner"
           - '{{ .Jsn }}'
+        {{- if .RunnerCustomCASecret }}
+        env:
+          - name: SSL_CERT_DIR
+            value: /etc/testkube/certs
+          - name: GIT_SSL_CAPATH
+            value: /etc/testkube/certs
+        {{- end }}
         volumeMounts:
         {{- if not (and  .ArtifactRequest (eq .ArtifactRequest.VolumeMountPath "/data")) }}
         - name: data-volume
@@ -29,6 +36,12 @@ spec:
         {{- if .CertificateSecret }}
         - name: {{ .CertificateSecret }}
           mountPath: /etc/certs
+        {{- end }}
+        {{- if .RunnerCustomCASecret }}
+        - name: {{ .RunnerCustomCASecret }}
+          mountPath: /etc/testkube/certs/testkube-custom-ca.pem
+          readOnly: true
+          subPath: ca.crt
         {{- end }}
         {{- if .ArtifactRequest }}
           {{- if and .ArtifactRequest.VolumeMountPath (or .ArtifactRequest.StorageClassName .ArtifactRequest.UseDefaultStorageClassName) }}
@@ -139,6 +152,12 @@ spec:
       - name: {{ .CertificateSecret }}
         secret:
           secretName: {{ .CertificateSecret }}
+      {{- end }}
+      {{- if .RunnerCustomCASecret }}
+      - name: {{ .RunnerCustomCASecret }}
+        secret:
+          secretName: {{ .RunnerCustomCASecret }}
+          defaultMode: 420
       {{- end }}
       {{- if .AgentAPITLSSecret }}
       - name: { { .AgentAPITLSSecret } }

--- a/charts/testkube-api/job-scraper-template.yml.tmpl
+++ b/charts/testkube-api/job-scraper-template.yml.tmpl
@@ -50,6 +50,8 @@ spec:
         env:
           - name: SSL_CERT_DIR
             value: /etc/testkube/certs
+          - name: GIT_SSL_CAPATH
+            value: /etc/testkube/certs
         {{- end }}
         volumeMounts:
         {{- if .RunnerCustomCASecret }}

--- a/charts/testkube-api/job-template.yml.tmpl
+++ b/charts/testkube-api/job-template.yml.tmpl
@@ -24,6 +24,8 @@ spec:
         env:
           - name: SSL_CERT_DIR
             value: /etc/testkube/certs
+          - name: GIT_SSL_CAPATH
+            value: /etc/testkube/certs
         {{- end }}
         volumeMounts:
         {{- if not (and  .ArtifactRequest (eq .ArtifactRequest.VolumeMountPath "/data")) }}
@@ -99,6 +101,8 @@ spec:
         env:
           - name: SSL_CERT_DIR
             value: /etc/testkube/certs
+          - name: GIT_SSL_CAPATH
+            value: /etc/testkube/certs
         {{- end }}
         volumeMounts:
         {{- if not (and  .ArtifactRequest (eq .ArtifactRequest.VolumeMountPath "/data")) }}
@@ -142,7 +146,7 @@ spec:
       {{- if not (and  .ArtifactRequest (eq .ArtifactRequest.VolumeMountPath "/data")) }}
       - name: data-volume
         emptyDir: {}
-      {{ end }} 
+      {{ end }}
       {{- if .CertificateSecret }}
       - name: {{ .CertificateSecret }}
         secret:

--- a/charts/testkube-api/slave-pod-template.yml.tmpl
+++ b/charts/testkube-api/slave-pod-template.yml.tmpl
@@ -21,12 +21,14 @@ spec:
     image: {{ .InitImage }}
     {{- end }}
     imagePullPolicy: IfNotPresent
-    command: 
+    command:
       - "/bin/runner"
       - '{{ .Jsn }}'
     {{- if .RunnerCustomCASecret }}
     env:
       - name: SSL_CERT_DIR
+        value: /etc/testkube/certs
+      - name: GIT_SSL_CAPATH
         value: /etc/testkube/certs
     {{- end }}
     volumeMounts:
@@ -99,7 +101,7 @@ spec:
       containerPort: {{ $port.ContainerPort }}
     {{- end}}
     {{- range $port := .Ports }}
-    {{- if eq $port.Name "server-port" }}  
+    {{- if eq $port.Name "server-port" }}
     livenessProbe:
       tcpSocket:
         port: {{ $port.ContainerPort }}


### PR DESCRIPTION
## Pull request description 

Only covers pre-built and container executors.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

- Fix job templates to be able to pull from Git repositories using private-CAs. Covers prebuilt and container executors only, not workflows.

## Fixes

- TKC-1901
- TKC-1911