### PR TITLE
release: default service account for testworkflows

### DIFF
--- a/charts/testkube-api/templates/role.yaml
+++ b/charts/testkube-api/templates/role.yaml
@@ -658,17 +658,22 @@ rules:
       - list
       - create
       - delete
+      - deletecollection
   - apiGroups:
       - ""
     resources:
       - pods
       - pods/log
+      - configmaps
+      - secrets
+      - events
     verbs:
       - get
       - watch
       - list
       - create
       - delete
+      - deletecollection
   - apiGroups:
       - metrics.k8s.io
     resources:
@@ -861,17 +866,22 @@ rules:
       - list
       - create
       - delete
+      - deletecollection
   - apiGroups:
       - ""
     resources:
       - pods
       - pods/log
+      - configmaps
+      - secrets
+      - events
     verbs:
       - get
       - watch
       - list
       - create
       - delete
+      - deletecollection
   - apiGroups:
       - metrics.k8s.io
     resources:

--- a/charts/testkube/values-demo.yaml
+++ b/charts/testkube/values-demo.yaml
@@ -12,12 +12,6 @@ global:
       effect: NoSchedule
   features:
     logsV2: false
-  testWorkflows:
-    globalTemplate:
-      enabled: true
-      spec:
-        pod:
-          serviceAccountName: testkube-api-server
 
 replicaCount: 1
 

--- a/charts/testkube/values-develop.yaml
+++ b/charts/testkube/values-develop.yaml
@@ -12,12 +12,6 @@ global:
       effect: NoSchedule
   features:
     logsV2: true
-  testWorkflows:
-    globalTemplate:
-      enabled: true
-      spec:
-        pod:
-          serviceAccountName: testkube-api-server
 
 replicaCount: 1
 

--- a/charts/testkube/values-stage.yaml
+++ b/charts/testkube/values-stage.yaml
@@ -11,12 +11,6 @@ global:
       effect: NoSchedule
   features:
     logsV2: true
-  testWorkflows:
-    globalTemplate:
-      enabled: true
-      spec:
-        pod:
-          serviceAccountName: testkube-api-server
     
 replicaCount: 1
 


### PR DESCRIPTION
## Pull request description 

* feat: use same ServiceAccount for Tests as for TestWorkflows (#847)

(cherry picked from commit fe154b9b83c2250dd651c88aadd4c268210b218c)


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test