### PR TITLE
fix: add missing patch/update permissions (required for updating ConfigMap of image inspector

### DIFF
--- a/charts/testkube-api/templates/role.yaml
+++ b/charts/testkube-api/templates/role.yaml
@@ -670,6 +670,8 @@ rules:
     verbs:
       - get
       - watch
+      - patch
+      - update
       - list
       - create
       - delete


### PR DESCRIPTION
## Pull request description 

```
{"level":"warn","ts":1716289269.2448988,"caller":"imageinspector/inspector.go:73","msg":"error while saving image details in the cache","registry":"","image":"bitnami/minio","error":"configmaps \"testkube-image-cache\" is forbidden: User \"system:serviceaccount:testkube:testkube-api-server-tests-job\" cannot patch resource \"configmaps\" in API group \"\" in the namespace \"testkube\""}
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
