### PR TITLE
fix: testkube-api: fix issue with generating rolebindings if rbac is disabled

### DIFF
--- a/charts/testkube-api/templates/rolebinding.yaml
+++ b/charts/testkube-api/templates/rolebinding.yaml
@@ -262,7 +262,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 
 ---
-
+# RBAC for additional namespaces
 {{- if .Values.additionalNamespaces }}
 {{- range .Values.additionalNamespaces }}
 {{- $rangeItem := . -}}
@@ -287,12 +287,11 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "testkube-api.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+# end range over additional namespaces
 {{- end }}
 ---
+# end of conditional generation of additional namespaces
 {{- end }}
-{{- end }}
-
----
 
 {{- if .Values.multinamespace.enabled }}
 apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
@@ -481,7 +480,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "testkube-api.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}    
+    namespace: {{ .Release.Namespace }}
 
 ---
 
@@ -577,8 +576,11 @@ subjects:
   - kind: ServiceAccount
     name: {{ $rangeItem.jobServiceAccountName }}
     namespace: {{ $rangeItem.namespace }}
+# end of conditional generation if generateTestJobRBAC is enabled
 {{- end }}
-
+# end of conditional generation if generateAPIServerRBAC is enabled
 {{- end }}
 {{- end }}
+{{- end }}
+# end of conditional generation if RBAC is enabled
 {{- end }}


### PR DESCRIPTION
## Pull request description 

Some RoleBindings were generated when the following was set `rbac.create: false`:
```
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: testexecutions-crb-release-name
  labels:
    app.kubernetes.io/version: "1.17.39"
    helm.sh/chart: testkube-api-1.17.39
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: api-server
    app.kubernetes.io/instance: release-name
    wd_service: testkube
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: testexecution-role-release-name
subjects:
  - kind: ServiceAccount
    name: testkube-api-server
    namespace: default
---
# Source: testkube/charts/testkube-api/templates/rolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: testsuiteexecutions-crb-release-name
  labels:
    app.kubernetes.io/version: "1.17.39"
    helm.sh/chart: testkube-api-1.17.39
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: api-server
    app.kubernetes.io/instance: release-name
    wd_service: testkube
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: testsuiteexecution-role-release-name
subjects:
  - kind: ServiceAccount
    name: testkube-api-server
    namespace: default
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-