### PR TITLE
fix: simplify API Server / Job permissions

### DIFF
--- a/charts/testkube-api/templates/role.yaml
+++ b/charts/testkube-api/templates/role.yaml
@@ -60,7 +60,6 @@ rules:
       - ""
     resources:
       - pods
-      - pods/log
     verbs:
       - get
       - watch
@@ -68,6 +67,14 @@ rules:
       - create
       - delete
       - deletecollection
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+      - watch
+      - list
 
 ---
 
@@ -663,10 +670,8 @@ rules:
       - ""
     resources:
       - pods
-      - pods/log
       - configmaps
       - secrets
-      - events
     verbs:
       - get
       - watch
@@ -676,6 +681,15 @@ rules:
       - create
       - delete
       - deletecollection
+  - apiGroups:
+      - ""
+    resources:
+      - events
+      - pods/log
+    verbs:
+      - get
+      - watch
+      - list
   - apiGroups:
       - metrics.k8s.io
     resources:
@@ -832,15 +846,22 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - pods
-      - pods/log
+    - pods
     verbs:
-      - get
-      - watch
-      - list
-      - create
-      - delete
-      - deletecollection
+    - get
+    - watch
+    - list
+    - create
+    - delete
+    - deletecollection
+  - apiGroups:
+    - ""
+    resources:
+    - pods/log
+    verbs:
+    - get
+    - watch
+    - list
 {{- end }}
 
 {{- if $rangeItem.generateTestJobRBAC }}
@@ -873,17 +894,26 @@ rules:
       - ""
     resources:
       - pods
-      - pods/log
       - configmaps
       - secrets
-      - events
     verbs:
       - get
       - watch
+      - patch
+      - update
       - list
       - create
       - delete
       - deletecollection
+  - apiGroups:
+      - ""
+    resources:
+      - events
+      - pods/log
+    verbs:
+      - get
+      - watch
+      - list
   - apiGroups:
       - metrics.k8s.io
     resources:

--- a/charts/testkube-api/templates/rolebinding.yaml
+++ b/charts/testkube-api/templates/rolebinding.yaml
@@ -262,6 +262,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 
 ---
+
 # RBAC for additional namespaces
 {{- if .Values.additionalNamespaces }}
 {{- range .Values.additionalNamespaces }}
@@ -287,9 +288,13 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "testkube-api.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-# end range over additional namespaces
-{{- end }}
+
 ---
+# end with provided value
+ {{- end }}
+# end range over additional namespaces
+ {{- end }}
+
 # end of conditional generation of additional namespaces
 {{- end }}
 
@@ -314,9 +319,9 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "testkube-api.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-{{- end }}
 
 ---
+{{- end }}
 
 {{- if not .Values.multinamespace.enabled }}
 apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
@@ -339,9 +344,9 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "testkube-api.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-{{- end }}
 
 ---
+{{- end }}
 
 apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
@@ -384,7 +389,6 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "testkube-api.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-{{ end }}
 
 ---
 


### PR DESCRIPTION
## Pull request description 

* Simplify permissions (i.e. to avoid problems with `deletecollection` for `pods/log`)
* Fix the `{{ end }}` clauses - some roles were not created (like `watchers-rb-{{namespace}}` cluster role)

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
