### PR TITLE
feat: Testkube workflow templates - disable beta templates in wizard

### DIFF
--- a/charts/testkube-api/templates/testworkflows/builtin-templates/beta/artillery.yaml
+++ b/charts/testkube-api/templates/testworkflows/builtin-templates/beta/artillery.yaml
@@ -5,6 +5,7 @@ metadata:
   name: official--artillery--beta
   labels:
     testkube.io/name: Artillery
+    testkube.io/wizard: disabled
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "19"

--- a/charts/testkube-api/templates/testworkflows/builtin-templates/beta/cypress.yaml
+++ b/charts/testkube-api/templates/testworkflows/builtin-templates/beta/cypress.yaml
@@ -5,6 +5,7 @@ metadata:
   name: official--cypress--beta
   labels:
     testkube.io/name: Cypress
+    testkube.io/wizard: disabled
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "19"

--- a/charts/testkube-api/templates/testworkflows/builtin-templates/beta/gradle.yaml
+++ b/charts/testkube-api/templates/testworkflows/builtin-templates/beta/gradle.yaml
@@ -5,6 +5,7 @@ metadata:
   name: official--gradle--beta
   labels:
     testkube.io/name: Gradle
+    testkube.io/wizard: disabled
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "19"

--- a/charts/testkube-api/templates/testworkflows/builtin-templates/beta/jmeter.yaml
+++ b/charts/testkube-api/templates/testworkflows/builtin-templates/beta/jmeter.yaml
@@ -5,6 +5,7 @@ metadata:
   name: official--jmeter--beta
   labels:
     testkube.io/name: JMeter
+    testkube.io/wizard: disabled
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "19"

--- a/charts/testkube-api/templates/testworkflows/builtin-templates/beta/k6.yaml
+++ b/charts/testkube-api/templates/testworkflows/builtin-templates/beta/k6.yaml
@@ -5,6 +5,7 @@ metadata:
   name: official--k6--beta
   labels:
     testkube.io/name: k6
+    testkube.io/wizard: disabled
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "19"

--- a/charts/testkube-api/templates/testworkflows/builtin-templates/beta/maven.yaml
+++ b/charts/testkube-api/templates/testworkflows/builtin-templates/beta/maven.yaml
@@ -5,6 +5,7 @@ metadata:
   name: official--maven--beta
   labels:
     testkube.io/name: Maven
+    testkube.io/wizard: disabled
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "19"

--- a/charts/testkube-api/templates/testworkflows/builtin-templates/beta/playwright.yaml
+++ b/charts/testkube-api/templates/testworkflows/builtin-templates/beta/playwright.yaml
@@ -5,6 +5,7 @@ metadata:
   name: official--playwright--beta
   labels:
     testkube.io/name: Playwright
+    testkube.io/wizard: disabled
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "19"

--- a/charts/testkube-api/templates/testworkflows/builtin-templates/beta/postman.yaml
+++ b/charts/testkube-api/templates/testworkflows/builtin-templates/beta/postman.yaml
@@ -5,6 +5,7 @@ metadata:
   name: official--postman--beta
   labels:
     testkube.io/name: Postman
+    testkube.io/wizard: disabled
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "19"


### PR DESCRIPTION
Because of `PATCH` the beta templates need to be specifically disabled - otherwise this label won't be removed and they will still be visible.