### PR TITLE
fix: pass artifact scraping to agent mode

### DIFF
--- a/charts/testkube-api/templates/_helpers.tpl
+++ b/charts/testkube-api/templates/_helpers.tpl
@@ -163,6 +163,10 @@ Define API environment in agent mode
 - name: TESTKUBE_PRO_MIGRATE
   value:  "{{ .Values.cloud.migrate }}"
 {{- end}}
+- name: "SCRAPPERENABLED"
+  value:  "{{ .Values.storage.scrapperEnabled }}"
+- name: "COMPRESSARTIFACTS"
+  value:  "{{ .Values.storage.compressArtifacts }}"
 - name: "NATS_EMBEDDED"
   value: "{{ .Values.nats.embedded }}"
 {{- if .Values.nats.enabled }}


### PR DESCRIPTION
## Pull request description 

Looks like https://github.com/kubeshop/helm-charts/pull/870 broke artifact scraping for cloud.

Previously the values:
```
    # -- Toggle whether to enable scraper in Testkube API
    scrapperEnabled: true
    # -- Toggle whether to compress artifacts in Testkube API
    compressArtifacts: true
```

were passed to both oss and agent mode, the PR didnt pass scraperEnabled to deployment yaml in cloud mode, which disables artifact scraping for them.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-