### PR TITLE
testkube: add support for global mounting of volumes

### DIFF
--- a/charts/testkube-api/templates/_helpers.tpl
+++ b/charts/testkube-api/templates/_helpers.tpl
@@ -188,6 +188,10 @@ Define API environment in agent mode
 {{- end }}
 {{- end }}
 {{- end }}
+- name: "SCRAPPERENABLED"
+  value:  "{{ .Values.storage.scrapperEnabled }}"
+- name: "COMPRESSARTIFACTS"
+  value:  "{{ .Values.storage.compressArtifacts }}"
 {{- end }}
 
 {{/*

--- a/charts/testkube-api/templates/_job-container-template.yaml.tpl
+++ b/charts/testkube-api/templates/_job-container-template.yaml.tpl
@@ -32,8 +32,14 @@ spec:
         command:
           - "/bin/runner"
           - '{{`{{ .Jsn }}`}}'
-        {{`{{- if .RunnerCustomCASecret }}`}}
         env:
+        {{- if .Values.global.tls.caCertPath }}
+          - name: SSL_CERT_DIR
+            value: {{ .Values.global.tls.caCertPath }}
+          - name: GIT_SSL_CAPATH
+            value: {{ .Values.global.tls.caCertPath }}
+        {{- end }}
+        {{`{{- if .RunnerCustomCASecret }}`}}
           - name: SSL_CERT_DIR
             value: /etc/testkube/certs
           - name: GIT_SSL_CAPATH
@@ -78,6 +84,9 @@ spec:
         {{`{{- end }}`}}
         {{`{{- end }}`}}
         {{- with .Values.additionalJobVolumeMounts }}
+        {{- toYaml . | nindent 8 -}}
+        {{- end }}
+        {{- with .Values.global.volumes.additionalVolumeMounts }}
         {{- toYaml . | nindent 8 -}}
         {{- end }}
       containers:
@@ -126,8 +135,14 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{`{{- if .RunnerCustomCASecret }}`}}
         env:
+        {{- if .Values.global.tls.caCertPath }}
+          - name: SSL_CERT_DIR
+            value: {{ .Values.global.tls.caCertPath }}
+          - name: GIT_SSL_CAPATH
+            value: {{ .Values.global.tls.caCertPath }}
+        {{- end }}
+        {{`{{- if .RunnerCustomCASecret }}`}}
           - name: SSL_CERT_DIR
             value: /etc/testkube/certs
           - name: GIT_SSL_CAPATH
@@ -216,6 +231,9 @@ spec:
         {{- with .Values.additionalJobVolumeMounts }}
         {{- toYaml . | nindent 8 -}}
         {{- end }}
+        {{- with .Values.global.volumes.additionalVolumeMounts }}
+        {{- toYaml . | nindent 8 -}}
+        {{- end }}
       volumes:
       {{`{{- if not (and  .ArtifactRequest (eq .ArtifactRequest.VolumeMountPath "/data")) }}`}}
       - name: data-volume
@@ -259,6 +277,9 @@ spec:
       {{`{{- end }}`}}
       {{`{{- end }}`}}
       {{- with .Values.additionalJobVolumes }}
+      {{- toYaml . | nindent 6 -}}
+      {{- end }}
+      {{- with .Values.global.volumes.additionalVolumes }}
       {{- toYaml . | nindent 6 -}}
       {{- end }}
       restartPolicy: Never

--- a/charts/testkube-api/templates/_job-scraper-template.yaml.tpl
+++ b/charts/testkube-api/templates/_job-scraper-template.yaml.tpl
@@ -65,8 +65,14 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{`{{- if .RunnerCustomCASecret }}`}}
         env:
+        {{- if .Values.global.tls.caCertPath }}
+          - name: SSL_CERT_DIR
+            value: {{ .Values.global.tls.caCertPath }}
+          - name: GIT_SSL_CAPATH
+            value: {{ .Values.global.tls.caCertPath }}
+        {{- end }}
+        {{`{{- if .RunnerCustomCASecret }}`}}
           - name: SSL_CERT_DIR
             value: /etc/testkube/certs
           - name: GIT_SSL_CAPATH
@@ -93,6 +99,9 @@ spec:
         {{- with .Values.additionalJobVolumeMounts }}
           {{- toYaml . | nindent 10 -}}
         {{- end }}
+        {{- with .Values.global.volumes.additionalVolumeMounts }}
+          {{- toYaml . | nindent 10 -}}
+        {{- end }}
       volumes:
       {{`{{- if .RunnerCustomCASecret }}`}}
         - name: {{`{{ .RunnerCustomCASecret }}`}}
@@ -113,6 +122,9 @@ spec:
         {{`{{- end }}`}}
       {{`{{- end }}`}}
       {{- with .Values.additionalJobVolumes }}
+        {{- toYaml . | nindent 8 -}}
+      {{- end }}
+      {{- with .Values.global.volumes.additionalVolumes }}
         {{- toYaml . | nindent 8 -}}
       {{- end }}
       restartPolicy: Never

--- a/charts/testkube-api/templates/_job-template.yaml.tpl
+++ b/charts/testkube-api/templates/_job-template.yaml.tpl
@@ -78,6 +78,9 @@ spec:
         {{- with .Values.additionalJobVolumeMounts }}
         {{- toYaml . | nindent 8 -}}
         {{- end }}
+        {{- with .Values.global.volumes.additionalVolumeMounts }}
+        {{- toYaml . | nindent 8 -}}
+        {{- end }}
       containers:
       {{`{{ if .Features.LogsV2 -}}`}}
       - name: "{{`{{ .Name }}`}}-logs"
@@ -123,8 +126,14 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{`{{- if .RunnerCustomCASecret }}`}}
         env:
+        {{- if .Values.global.tls.caCertPath }}
+          - name: SSL_CERT_DIR
+            value: {{ .Values.global.tls.caCertPath }}
+          - name: GIT_SSL_CAPATH
+            value: {{ .Values.global.tls.caCertPath }}
+        {{- end }}
+        {{`{{- if .RunnerCustomCASecret }}`}}
           - name: SSL_CERT_DIR
             value: /etc/testkube/certs
           - name: GIT_SSL_CAPATH
@@ -171,6 +180,9 @@ spec:
         {{- with .Values.additionalJobVolumeMounts }}
         {{- toYaml . | nindent 8 -}}
         {{- end }}
+        {{- with .Values.global.volumes.additionalVolumeMounts }}
+        {{- toYaml . | nindent 8 -}}
+        {{- end }}
       volumes:
       {{`{{- if not (and  .ArtifactRequest (eq .ArtifactRequest.VolumeMountPath "/data")) }}`}}
       - name: data-volume
@@ -214,6 +226,9 @@ spec:
       {{`{{- end }}`}}
       {{`{{- end }}`}}
       {{- with .Values.additionalJobVolumes }}
+      {{- toYaml . | nindent 6 -}}
+      {{- end }}
+      {{- with .Values.global.volumes.additionalVolumes }}
       {{- toYaml . | nindent 6 -}}
       {{- end }}
       restartPolicy: Never

--- a/charts/testkube-api/templates/_slave-pod-template.yaml.tpl
+++ b/charts/testkube-api/templates/_slave-pod-template.yaml.tpl
@@ -113,6 +113,13 @@ spec:
     resources:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    env:
+    {{- if .Values.global.tls.caCertPath }}
+    - name: SSL_CERT_DIR
+      value: {{ .Values.global.tls.caCertPath }}
+    - name: GIT_SSL_CAPATH
+      value: {{ .Values.global.tls.caCertPath }}
+    {{- end }}
     ports:
     {{`{{- range $port := .Ports }}`}}
     - name: {{`{{ $port.Name }}`}}
@@ -184,6 +191,12 @@ spec:
       mountPath: {{`{{ $secret.MountPath }}`}}
     {{`{{- end }}`}}
     {{`{{- end }}`}}
+    {{- with .Values.additionalJobVolumeMounts }}
+    {{- toYaml . | nindent 4 -}}
+    {{- end }}
+    {{- with .Values.global.volumes.additionalVolumeMounts }}
+    {{- toYaml . | nindent 4 -}}
+    {{- end }}
   volumes:
   {{`{{- if not (and  .ArtifactRequest (eq .ArtifactRequest.VolumeMountPath "/data")) }}`}}
   - name: data-volume
@@ -221,6 +234,12 @@ spec:
       secretName: {{`{{ $secret.Reference.Name }}`}}
   {{`{{- end }}`}}
   {{`{{- end }}`}}
+  {{- with .Values.additionalJobVolumes }}
+  {{- toYaml . | nindent 2 -}}
+  {{- end }}
+  {{- with .Values.global.volumes.additionalVolumes }}
+  {{- toYaml . | nindent 2 -}}
+  {{- end }}
   restartPolicy: Always
   {{`{{- if .ServiceAccountName }}`}}
   serviceAccountName: {{`{{ .ServiceAccountName }}`}}

--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -181,6 +181,12 @@ spec:
             - name: TESTKUBE_EXECUTION_NAMESPACES
               value: "{{ $value }}"
             {{- end }}
+            {{- if .Values.global.tls.caCertPath }}
+            - name: SSL_CERT_DIR
+              value: {{ .Values.global.tls.caCertPath }}
+            - name: GIT_SSL_CAPATH
+              value: {{ .Values.global.tls.caCertPath }}
+            {{- end }}
             {{- if .Values.cloud.tls.customCaSecretRef }}
             - name: SSL_CERT_DIR
               value: /etc/testkube/certs
@@ -250,14 +256,17 @@ spec:
               readOnly: true
             {{- end }}
             {{- end }}
-            {{- with .Values.additionalVolumeMounts }}
-            {{- toYaml . | nindent 12 -}}
-            {{- end }}
             {{- if .Values.cloud.tls.customCaSecretRef }}
             - mountPath: /etc/testkube/certs/testkube-custom-ca.pem
               name: {{ .Values.cloud.tls.customCaSecretRef }}
               readOnly: true
               subPath: ca.crt
+            {{- end }}
+            {{- with .Values.additionalVolumeMounts }}
+            {{- toYaml . | nindent 12 -}}
+            {{- end }}
+            {{- with .Values.global.volumes.additionalVolumeMounts }}
+            {{- toYaml . | nindent 12 -}}
             {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -288,14 +297,17 @@ spec:
             secretName: {{ .Values.testkubeLogs.tls.certSecret.name }}
         {{- end }}
         {{- end }}
-        {{- with .Values.additionalVolumes }}
-        {{- toYaml . | nindent 8 -}}
-        {{- end }}
         {{- if .Values.cloud.tls.customCaSecretRef }}
         - name: {{ .Values.cloud.tls.customCaSecretRef }}
           secret:
             defaultMode: 420
             secretName: {{ .Values.cloud.tls.customCaSecretRef }}
+        {{- end }}
+        {{- with .Values.additionalVolumes }}
+        {{- toYaml . | nindent 8 -}}
+        {{- end }}
+        {{- with .Values.global.volumes.additionalVolumes }}
+        {{- toYaml . | nindent 8 -}}
         {{- end }}
       {{- if .Values.affinity }}
       affinity:

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -13,6 +13,18 @@ global:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  ## Global TLS settings
+  tls:
+    ## Toggle whether to globally skip certificate verification
+    skipVerify: false
+    ## Path to the PEM-encoded CA certificate file (needs to be mounted to the container previously)
+    caCertPath: ""
+  ## Global volume settings (API & Test Jobs)
+  volumes:
+    ## Additional volumes to be added to the Testkube API container and Test Jobs containers
+    additionalVolumes: []
+    ## Additional volume mounts to be added to the Testkube API container and Test Jobs containers
+    additionalVolumeMounts: []
   features:
     logsV2: false
     whitelistedContainers: init,logs,scraper

--- a/charts/testkube/README.md
+++ b/charts/testkube/README.md
@@ -2,7 +2,7 @@
 
 Testkube is an open-source platform that simplifies the deployment and management of automated testing infrastructure.
 
-![Version: 2.0.3](https://img.shields.io/badge/Version-2.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.0.10](https://img.shields.io/badge/Version-2.0.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Install
 
@@ -136,7 +136,7 @@ kubectl label --overwrite crds scripts.tests.testkube.io app.kubernetes.io/manag
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../global | global | 0.1.2 |
-| file://../testkube-api | testkube-api | 2.0.1 |
+| file://../testkube-api | testkube-api | 2.0.6 |
 | file://../testkube-logs | testkube-logs | 0.2.0 |
 | file://../testkube-operator | testkube-operator | 2.0.0 |
 | https://charts.bitnami.com/bitnami | mongodb | 13.10.1 |
@@ -146,7 +146,7 @@ kubectl label --overwrite crds scripts.tests.testkube.io app.kubernetes.io/manag
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global | object | `{"affinity":{},"annotations":{},"features":{"logsV2":false,"whitelistedContainers":"init,logs,scraper"},"imagePullSecrets":[],"imageRegistry":"","labels":{},"nodeSelector":{},"testWorkflows":{"createOfficialTemplates":true,"createServiceAccountTemplates":true,"globalTemplate":{"enabled":false,"name":"global-template","spec":{}}},"tolerations":[{"effect":"NoSchedule","key":"kubernetes.io/arch","operator":"Equal","value":"arm64"}]}` | Important! Please, note that this will override sub-chart image parameters. |
+| global | object | `{"affinity":{},"annotations":{},"features":{"logsV2":false,"whitelistedContainers":"init,logs,scraper"},"imagePullSecrets":[],"imageRegistry":"","labels":{},"nodeSelector":{},"testWorkflows":{"createOfficialTemplates":true,"createServiceAccountTemplates":true,"globalTemplate":{"enabled":false,"name":"global-template","spec":{}}},"tls":{"caCertPath":"","skipVerify":false},"tolerations":[{"effect":"NoSchedule","key":"kubernetes.io/arch","operator":"Equal","value":"arm64"}],"volumes":{"additionalVolumeMounts":[],"additionalVolumes":[]}}` | Important! Please, note that this will override sub-chart image parameters. |
 | global.affinity | object | `{}` | Affinity rules to add to all deployed Pods |
 | global.annotations | object | `{}` | Annotations to add to all deployed objects |
 | global.features.logsV2 | bool | `false` | Toggle whether to enable V2 log support |
@@ -162,7 +162,12 @@ kubectl label --overwrite crds scripts.tests.testkube.io app.kubernetes.io/manag
 | global.testWorkflows.globalTemplate.enabled | bool | `false` | Is global template enabled |
 | global.testWorkflows.globalTemplate.name | string | `"global-template"` | Name of the global template |
 | global.testWorkflows.globalTemplate.spec | object | `{}` | Specification for the global template |
+| global.tls.caCertPath | string | `""` | Path to the CA certificate file |
+| global.tls.skipVerify | bool | `false` | Toggle whether to globally skip certificate verification |
 | global.tolerations | list | `[{"effect":"NoSchedule","key":"kubernetes.io/arch","operator":"Equal","value":"arm64"}]` | Tolerations to add to all deployed pods |
+| global.volumes | object | `{"additionalVolumeMounts":[],"additionalVolumes":[]}` | Global volume settings (API & Test Jobs) |
+| global.volumes.additionalVolumeMounts | list | `[]` | Additional volume mounts to be added to the Testkube API container and Test Jobs containers |
+| global.volumes.additionalVolumes | list | `[]` | Additional volumes to be added to the Testkube API container and Test Jobs containers |
 | mongodb.auth.enabled | bool | `false` | Toggle whether to enable MongoDB authentication |
 | mongodb.containerSecurityContext | object | `{}` | Security Context for MongoDB container |
 | mongodb.enabled | bool | `true` | Toggle whether to install MongoDB |
@@ -233,6 +238,7 @@ kubectl label --overwrite crds scripts.tests.testkube.io app.kubernetes.io/manag
 | testkube-api.cloud.uiUrl | string | `""` |  |
 | testkube-api.cloud.url | string | `"agent.testkube.io:443"` | Testkube Cloud API URL |
 | testkube-api.clusterName | string | `""` | cluster name to be used in events |
+| testkube-api.containerResources | object | `{}` |  |
 | testkube-api.dashboardUri | string | `""` | dashboard uri to be used in notification events |
 | testkube-api.defaultStorageClassName | string | `""` | default storage class name for PVC volumes |
 | testkube-api.disableSecretCreation | bool | `false` | disable secret creation for tests and test sources |
@@ -259,6 +265,7 @@ kubectl label --overwrite crds scripts.tests.testkube.io app.kubernetes.io/manag
 | testkube-api.imageTwToolkit.digest | string | `""` | Test Workflows image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag |
 | testkube-api.imageTwToolkit.registry | string | `"docker.io"` | Test Workflows image registry |
 | testkube-api.imageTwToolkit.repository | string | `"kubeshop/testkube-tw-toolkit"` | Test Workflows image name |
+| testkube-api.initContainerResources | object | `{}` |  |
 | testkube-api.jobAnnotations | object | `{}` |  |
 | testkube-api.jobPodAnnotations | object | `{}` |  |
 | testkube-api.jobServiceAccountName | string | `""` | SA that is used by a job. Can be annotated with the IAM Role Arn to access S3 service in AWS Cloud. |
@@ -266,6 +273,7 @@ kubectl label --overwrite crds scripts.tests.testkube.io app.kubernetes.io/manag
 | testkube-api.livenessProbe.initialDelaySeconds | int | `15` | Initial delay for liveness probe |
 | testkube-api.logs.bucket | string | `"testkube-logs"` | Bucket should be specified if storage is "minio" |
 | testkube-api.logs.storage | string | `"minio"` | Log storage can either be "minio" or "mongo" |
+| testkube-api.logsV2ContainerResources | object | `{}` |  |
 | testkube-api.minio.accessModes | list | `["ReadWriteOnce"]` | PVC Access Modes for Minio. The volume is mounted as read-write by a single node. |
 | testkube-api.minio.affinity | object | `{}` | Affinity for pod assignment. |
 | testkube-api.minio.enabled | bool | `true` | Toggle whether to install MinIO |
@@ -317,6 +325,7 @@ kubectl label --overwrite crds scripts.tests.testkube.io app.kubernetes.io/manag
 | testkube-api.readinessProbe | object | `{"initialDelaySeconds":30}` | Testkube API Readiness probe parameters |
 | testkube-api.readinessProbe.initialDelaySeconds | int | `30` | Initial delay for readiness probe |
 | testkube-api.resources | object | `{"requests":{"cpu":"200m","memory":"200Mi"}}` | Testkube API resource requests and limits |
+| testkube-api.scraperContainerResources | object | `{}` |  |
 | testkube-api.securityContext | object | `{}` | Security Context for testkube-api container |
 | testkube-api.service.annotations | object | `{}` | Service Annotations |
 | testkube-api.service.labels | object | `{}` | Service labels |

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -32,6 +32,18 @@ global:
     ## scraper - scrape logs from testkube scraper container
     # -- Comma-separated array of containers which should get scraped for logs
     whitelistedContainers: init,logs,scraper
+  ## Global TLS settings
+  tls:
+    # -- Toggle whether to globally skip certificate verification
+    skipVerify: false
+    # -- Path to the PEM-encoded CA certificate file (needs to be mounted to the container previously)
+    caCertPath: ""
+  # -- Global volume settings (API & Test Jobs)
+  volumes:
+    # -- Additional volumes to be added to the Testkube API container and Test Jobs containers
+    additionalVolumes: []
+    # -- Additional volume mounts to be added to the Testkube API container and Test Jobs containers
+    additionalVolumeMounts: []
   # -- Test Workflows configuration
   testWorkflows:
     # -- Create TestWorkflowTemplates to easily use the service account


### PR DESCRIPTION
## Pull request description 

CHANGELOG:
* add support for global volume mounts (mounted to both API and Test Jobs)
* add support for defining global CA cert path
* fix issue with scraper being disabled in agent mode

Example how to inject CA cert:
```
global:
  tls:
    caCertPath: /etc/testkube/certs
  volumes:
    additionalVolumes:
      - name: custom-ca
        secret:
          secretName: custom-cert
    additionalVolumeMounts:
      - name: custom-ca
        mountPath: /etc/testkube/certs
        readOnly: true
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-