### PR TITLE
indent to 8 for tolerations and nodeSelector

### DIFF
--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -319,15 +319,15 @@ spec:
       {{- end }}
       {{- if .Values.tolerations }}
       tolerations:
-      {{- toYaml .Values.tolerations | nindent 6 }}
+      {{- toYaml .Values.tolerations | nindent 8 }}
       {{- else if .Values.global.tolerations }}
       tolerations:
-      {{- toYaml .Values.global.tolerations | nindent 6 }}
+      {{- toYaml .Values.global.tolerations | nindent 8 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
-      {{- toYaml .Values.nodeSelector | nindent 6 }}
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- else if .Values.global.nodeSelector }}
       nodeSelector:
-      {{- toYaml .Values.global.nodeSelector | nindent 6 }}
+      {{- toYaml .Values.global.nodeSelector | nindent 8 }}
       {{- end }}

--- a/charts/testkube-logs/templates/deployment.yaml
+++ b/charts/testkube-logs/templates/deployment.yaml
@@ -199,10 +199,10 @@ spec:
       {{- end }}
       {{- if .Values.tolerations }}
       tolerations:
-      {{- toYaml .Values.tolerations | nindent 6 }}
+      {{- toYaml .Values.tolerations | nindent 8 }}
       {{- else if .Values.global.tolerations }}
       tolerations:
-      {{- toYaml .Values.global.tolerations | nindent 6 }}
+      {{- toYaml .Values.global.tolerations | nindent 8 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
The current indentation is set to 6 which places the value on the same level as the tolerations: or the nodeSelector:

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-