### PR TITLE
fix: slack config

### DIFF
--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -86,10 +86,6 @@ spec:
             - name: SLACK_TOKEN
               value: "{{ .Values.slackToken }}"
             {{- end }}
-            {{- if .Values.slackConfig }}
-            - name: SLACK_CONFIG
-              value:  "{{ .Values.slackConfig }}"
-            {{- end }}
             {{- if .Values.slackTemplate }}
             - name: SLACK_TEMPLATE
               value:  "{{ .Values.slackTemplate }}"


### PR DESCRIPTION
## Pull request description 

This `SLACK_CONFIG` variable is incorrectly set with a non-JSON encoded value, and it supersedes the proper config provided through the `ConfigMap`.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

- TKC-2441