### PR TITLE
fix(tracetest): fix provisioning importing in configmap

### DIFF
--- a/charts/tracetest/templates/configmap.yaml
+++ b/charts/tracetest/templates/configmap.yaml
@@ -17,7 +17,8 @@ data:
       {{- toYaml .Values.telemetry | nindent 6 }}
     server:
       {{- toYaml .Values.server | nindent 6 }}
-  provisioning.yaml: |-
-    {{- toYaml .Values.provisioning | nindent 4 }}
+  {{- $provision := .Values.provisioning }}
+  provisioning.yaml: |- 
+  {{- $provision | nindent 4 }}
 ---
 {{- end }}


### PR DESCRIPTION
## Pull request description 

This PR fixes a bug on the chart causing provisioning to not work. It was failing with this message: 

```
2024/09/09 16:17:45 [provisioning] attempting file:  /app/config/provisioning.yaml
2024/09/09 16:17:45 [provisioning] error: cannot unmarshal yaml for provisioning file: [1:1] scalar was used where mapping is expected
    >  1 | |
           ^
```

The issue was caused by an incorrect usage of a value in the configmap template, causing the provisioning file to look like this:

```yaml
apiVersion: v1
data:
  config.yaml: |-
    # ...
  provisioning.yaml: |-
    | # this line here was the issue
      ---
      type: DataStore
      spec:
        name: Jaeger
        # Indicates that this datastore is a jaeger instance
        type: jaeger
        # Configures how tracetest connects to jaeger.
        jaeger:
          endpoint: jaeger-query:16685
          tls:
            insecure: true
      ---
      type: PollingProfile
      spec:
        name: Custom Profile
        strategy: periodic
        default: true
        periodic:
          timeout: 30s
          retryDelay: 500ms
```

An extra `|` pipe character prependend to the file was causing the provisioner to fail to parse the file, since it's invalid yaml.

This PR fixes the configmap template.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-