### PR TITLE
fix: add /tmp as a volume to the API Server

### DIFF
--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -234,6 +234,8 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            - mountPath: /tmp
+              name: testkube-tmp
             {{- if .Values.nats.embedded }}
             - mountPath: /app/nats
               name: testkube-nats
@@ -274,6 +276,8 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
+        - name: testkube-tmp
+          emptyDir: {}
         - name: testkube-config
           configMap:
             name: {{ include "testkube-api.fullname" . }}


### PR DESCRIPTION
## Pull request description 

* after https://github.com/kubeshop/testkube/pull/5866 we will be streaming logs through the file system
* to ensure that it won't break for Users who have `readOnlyRootFilesystem`, we should mount it there

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
