### PR TITLE
feat: add support for external global template

### DIFF
--- a/charts/testkube-api/README.md
+++ b/charts/testkube-api/README.md
@@ -84,6 +84,7 @@ A Helm chart for Testkube api
 | global.testWorkflows.createOfficialTemplates | bool | `true` |  |
 | global.testWorkflows.createServiceAccountTemplates | bool | `true` |  |
 | global.testWorkflows.globalTemplate.enabled | bool | `false` |  |
+| global.testWorkflows.globalTemplate.external | bool | `false` |  |
 | global.testWorkflows.globalTemplate.name | string | `"global-template"` |  |
 | global.testWorkflows.globalTemplate.spec | object | `{}` |  |
 | global.tls.caCertPath | string | `""` |  |

--- a/charts/testkube-api/templates/testworkflows/builtin-templates/global-template.yaml
+++ b/charts/testkube-api/templates/testworkflows/builtin-templates/global-template.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.testWorkflows.globalTemplate.enabled }}
+{{- if and .Values.global.testWorkflows.globalTemplate.enabled (not .Values.global.testWorkflows.globalTemplate.external) }}
 apiVersion: testworkflows.testkube.io/v1
 kind: TestWorkflowTemplate
 metadata:

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -33,6 +33,7 @@ global:
     createOfficialTemplates: true
     globalTemplate:
       enabled: false
+      external: false
       name: global-template
       spec: {}
 

--- a/charts/testkube/README.md
+++ b/charts/testkube/README.md
@@ -163,6 +163,7 @@ kubectl label --overwrite crds scripts.tests.testkube.io app.kubernetes.io/manag
 | global.testWorkflows.globalTemplate | object | `{"enabled":false,"name":"global-template","spec":{}}` | Global TestWorkflowTemplate that will be automatically included for all executions |
 | global.testWorkflows.globalTemplate.enabled | bool | `false` | Is global template enabled |
 | global.testWorkflows.globalTemplate.name | string | `"global-template"` | Name of the global template |
+| global.testWorkflows.globalTemplate.external | bool | `false` | Is the global template sourced externally? (otherwise it's created from spec below) |
 | global.testWorkflows.globalTemplate.spec | object | `{}` | Specification for the global template |
 | global.tls.caCertPath | string | `""` | Path to the PEM-encoded CA certificate file (needs to be mounted to the container previously) |
 | global.tolerations | list | `[{"effect":"NoSchedule","key":"kubernetes.io/arch","operator":"Equal","value":"arm64"}]` | Tolerations to add to all deployed pods |

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -56,6 +56,8 @@ global:
       enabled: false
       # -- Name of the global template
       name: global-template
+      # -- Is the global template sourced externally? (otherwise it's created from spec below)
+      external: false
       # -- Specification for the global template
       spec: {}
       # spec:


### PR DESCRIPTION
## Pull request description 

```yaml
global:
  globalTemplate:
    enabled: true
    external: true
    name: my-own-global-template
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Fixes

* https://linear.app/kubeshop/issue/TKC-2614