### PR TITLE
fix: revert "fix: update rbac proxy image to address cve"

### DIFF
--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -909,7 +909,7 @@ testkube-operator:
       # -- Testkube Operator rbac-proxy image repository
       repository: brancz/kube-rbac-proxy
       # -- Testkube Operator rbac-proxy image tag
-      tag: "master-2024-12-13-af1a90b6"
+      tag: "v0.18.1"
       # -- Testkube Operator rbac-proxy k8s secret for private registries
       pullSecrets: []
     # -- Testkube Operator rbac-proxy resource settings


### PR DESCRIPTION
This reverts commit 0cfa37b2da0e8ae5e45618be6d886bb680cf8d6c.

## Pull request description 

causes exception:

```
Defaulted container "kube-rbac-proxy" out of: kube-rbac-proxy, manager
panic: version string "" doesn't match expected regular expression: "^v(\d+\.\d+\.\d+)"

goroutine 1 [running]:
k8s.io/component-base/metrics.parseVersion({{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x1c55f00, 0x28}, {0x0, 0x0}, ...})
        /home/runner/go/pkg/mod/k8s.io/component-base@v0.31.3/metrics/version_parser.go:47 +0x1b4
k8s.io/component-base/metrics.newKubeRegistry({{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x1c55f00, 0x28}, {0x0, 0x0}, ...})
        /home/runner/go/pkg/mod/k8s.io/component-base@v0.31.3/metrics/registry.go:371 +0xec
k8s.io/component-base/metrics.NewKubeRegistry()
        /home/runner/go/pkg/mod/k8s.io/component-base@v0.31.3/metrics/registry.go:385 +0x6c
k8s.io/component-base/metrics/legacyregistry.init()
        /home/runner/go/pkg/mod/k8s.io/component-base@v0.31.3/metrics/legacyregistry/registry.go:31 +0x1c
 ```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-