### PR TITLE
fix: duplicate description field in webhook template

### DIFF
--- a/charts/testkube-operator/templates/executor.testkube.io_webhooktemplates.yaml
+++ b/charts/testkube-operator/templates/executor.testkube.io_webhooktemplates.yaml
@@ -138,7 +138,6 @@ spec:
                   type: object
                   required:
                   - name
-                description: webhook parameters
                 type: array
               payloadObjectField:
                 description: will load the generated payload for notification inside


### PR DESCRIPTION
## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-