### PR TITLE
fix: allow lack of global template

### DIFF
--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -202,12 +202,14 @@ spec:
               value: "{{ include "testkube-tw-init.image" . }}"
             {{- if .Values.global.testWorkflows.globalTemplate.enabled }}
             {{- if .Values.global.testWorkflows.globalTemplate.inline }}
+            {{- if .Values.global.testWorkflows.globalTemplate.spec }}
             - name: TESTKUBE_GLOBAL_WORKFLOW_TEMPLATE_INLINE
-              {{- if and .Values.global.testWorkflows.globalTemplate.spec (kindIs "map" .Values.global.testWorkflows.globalTemplate.spec) }}
+              {{- if kindIs "map" .Values.global.testWorkflows.globalTemplate.spec }}
               value: {{ toJson .Values.global.testWorkflows.globalTemplate.spec | quote }}
               {{- else }}
               value: {{ toJson (fromYaml .Values.global.testWorkflows.globalTemplate.spec) | quote }}
               {{- end }}
+            {{- end }}
             {{- else }}
             - name: TESTKUBE_GLOBAL_WORKFLOW_TEMPLATE_NAME
               value: "{{ .Values.global.testWorkflows.globalTemplate.name }}"


### PR DESCRIPTION
## Pull request description 

* Fix for https://github.com/kubeshop/helm-charts/pull/985
* Ignore when `inline: true` without `spec`

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
