### PR TITLE
fix: update certgen image to fix cves

### DIFF
--- a/charts/testkube-operator/README.md
+++ b/charts/testkube-operator/README.md
@@ -98,7 +98,7 @@ A Helm chart for the testkube-operator (installs needed CRDs only for now)
 | webhook.patch.image.pullPolicy | string | `"IfNotPresent"` |  |
 | webhook.patch.image.pullSecrets | list | `[]` |  |
 | webhook.patch.image.registry | string | `"docker.io"` |  |
-| webhook.patch.image.repository | string | `"dpejcev/kube-webhook-certgen"` |  |
+| webhook.patch.image.repository | string | `"kubeshop/kube-webhook-certgen"` |  |
 | webhook.patch.image.tag | string | `"1.0.11"` |  |
 | webhook.patch.labels | object | `{}` |  |
 | webhook.patch.nodeSelector."kubernetes.io/os" | string | `"linux"` |  |

--- a/charts/testkube-operator/values.yaml
+++ b/charts/testkube-operator/values.yaml
@@ -205,7 +205,7 @@ webhook:
     image:
       registry: docker.io
       repository: kubeshop/kube-webhook-certgen
-      tag: 0.0.4
+      tag: 0.0.7
       pullPolicy: IfNotPresent
       pullSecrets: []
     ## Annotations to add to the patch Job


### PR DESCRIPTION
## Pull request description 

```
kubeshop/kube-webhook-certgen: docker scout cves kubeshop/kube-webhook-certgen:0.0.7                                                                                                                            
    i New version 1.16.1 available (installed version is 1.15.1) at https://github.com/docker/scout-cli
    ✓ Pulled
    ✓ Image stored for indexing
    ✓ Indexed 49 packages
    ✓ No vulnerable package detected


## Overview

                    │            Analyzed Image
────────────────────┼────────────────────────────────────────
  Target            │  kubeshop/kube-webhook-certgen:0.0.7
    digest          │  bf6d7698fbb7
    platform        │ linux/arm64
    vulnerabilities │    0C     0H     0M     0L
    size            │ 12 MB
    packages        │ 49


## Packages and Vulnerabilities

  No vulnerable packages detected

```


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-