### PR TITLE
fix: add missing property in the testkube umbrella chart

### DIFF
--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -471,6 +471,16 @@ testkube-api:
     orgId: ""
     ## -- Environment ID
     envId: ""
+    ## Retrieve cloud information from existing secret
+    existingSecret:
+      ## Name of the secret. If set, this will be used instead of the above values
+      name: ""
+      ## Key for the License Key
+      key: ""
+      ## Key for the Organization ID
+      orgId: ""
+      ## Key for the Environment ID
+      envId: ""
     ## -- true if migration from OSS
     migrate: ""
     tls:


### PR DESCRIPTION
## Pull request description 

Testkube chart was missing a property in its values.yaml file that allow users to install agent using an existing secret to manage key, orgId, and envId param needed to connect agent with a Control Plane.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

- Add existingSecret property from testkube-api into the umbrella chart values.yaml file.