### PR TITLE
fix: avoid default sync to Cloud

### DIFF
--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -553,7 +553,7 @@ testkube-api:
       ## Should it copy data from Control Plane to Kubernetes
       syncCloudToKubernetes: false
       ## Should it copy data from Kubernetes to Control Plane
-      syncKubernetesToCloud: true
+      syncKubernetesToCloud: false
       ## Define the naming patterns for resources in different sources
       namePatterns:
         ## Name pattern for resources in the Control Plane


### PR DESCRIPTION
## Pull request description 

* by default it will move to Cloud, but if Cloud has CRD storage enabled it will go back to the cluster.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test