### PR TITLE
fix: testkube runner volumen name

### DIFF
--- a/charts/testkube-runner/templates/deployment.yaml
+++ b/charts/testkube-runner/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
         - name: nats
           emptyDir: {}
         {{- if .Values.cloud.tls.customCa.secretRef.name }}
-        - name: customCa
+        - name: custom-ca
           secret:
             defaultMode: 420
             secretName: {{ .Values.cloud.tls.customCa.secretRef.name }}
@@ -149,7 +149,7 @@ spec:
             - name: nats
               mountPath: /app/nats
             {{- if .Values.cloud.tls.customCa.secretRef.name }}
-            - name: customCa
+            - name: custom-ca
               mountPath: /etc/testkube/certs/testkube-custom-ca.pem
               readOnly: true
               subPath: "{{ .Values.cloud.tls.customCa.secretRef.key }}"


### PR DESCRIPTION
## Pull request description 

Name of the runner volume do not support uppercase, fixing to match with kubernetes convention.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

- testkube runner volumen name