### PR TITLE
feat: Enable Agent based Executor controllers

### DIFF
--- a/charts/testkube-api/templates/deployment.yaml
+++ b/charts/testkube-api/templates/deployment.yaml
@@ -255,6 +255,8 @@ spec:
             {{- end }}
             - name: ALLOW_LOW_SECURITY_FIELDS
               value: "{{ .Values.allowLowSecurityFields }}"
+            - name: ENABLE_K8S_CONTROLLERS
+              value: "{{ .Values.next.controllers.enabled }}"
           image: {{ include "testkube-api.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -200,6 +200,12 @@ next:
     ## Should it manage cron jobs
     enabled: true
 
+  ## Configure control of TestKube custom resources in this installation.
+  # - tkcagnt_*** - Super Agent
+  controllers:
+    ## Should it manage Kubernetes resources
+    enabled: true
+
 ## Testkube API Deployment parameters
 ## Running Testkube in Agent mode
 cloud:

--- a/charts/testkube/Chart.yaml
+++ b/charts/testkube/Chart.yaml
@@ -8,7 +8,6 @@ dependencies:
     version: 2.1.146
     #repository: https://kubeshop.github.io/helm-charts
     repository: "file://../testkube-operator"
-    condition: testkube-operator.enabled
   - name: mongodb
     condition: mongodb.enabled
     version: 13.10.1

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -980,7 +980,7 @@ testkube-api:
 
 testkube-operator:
   ## deploy Operator chart
-  enabled: true
+  enabled: false
   ## namespace to deploy Testkube Operator. Default is .Release.Namespace
   namespace: ""
   # should roles and roles bindings be created

--- a/charts/testkube/values.yaml
+++ b/charts/testkube/values.yaml
@@ -573,6 +573,12 @@ testkube-api:
       ## Should it manage cron jobs
       enabled: true
 
+    ## Configure control of TestKube custom resources in this installation.
+    # - tkcagnt_*** - Super Agent
+    controllers:
+      ## Should it manage Kubernetes resources
+      enabled: true
+
   # ref: https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-arm-workloads-for-deployment#node-affinity-multi-arch-arm
   # -- Tolerations to schedule a workload to nodes with any architecture type. Required for deployment to GKE cluster.
   tolerations: []


### PR DESCRIPTION
Tweaks the charts to prevent deployment of the `operator` whilst simultaneously enabling the controllers ported to the `agent`.

Waiting on:
- https://github.com/kubeshop/testkube/pull/6386
- https://github.com/kubeshop/testkube-operator/pull/330