### PR TITLE
feat: Enable runner self-registration

### DIFF
--- a/charts/testkube-runner/templates/deployment.yaml
+++ b/charts/testkube-runner/templates/deployment.yaml
@@ -323,8 +323,6 @@ spec:
           {{- if .Values.runner.register.token }}
             - name: TESTKUBE_PRO_AGENT_REGISTRATION_TOKEN
               value: "{{ .Values.runner.register.token }}"
-            - name: TESTKUBE_PRO_ENV_ID
-              value: "{{ .Values.runner.envId }}"
             - name: ENABLE_SECRETS_ENDPOINT
               value: "true"
             - name: SELF_REGISTRATION_SECRET

--- a/charts/testkube-runner/templates/deployment.yaml
+++ b/charts/testkube-runner/templates/deployment.yaml
@@ -330,11 +330,11 @@ spec:
             - name: SELF_REGISTRATION_SECRET
               value: "self-registration"
             - name: SECRET_CREATION_PREFIX
-              value: "testkube-"
+              value: "{{ include "testkube-runner.fullname" . }}-{{ now | date "20060102150405" }}-"
             - name: FLOATING_RUNNER
               value: "{{ .Values.runner.register.floating }}"
           envFrom:
             - secretRef:
-                name: testkube-self-registration
+                name: "{{ include "testkube-runner.fullname" . }}-{{ now | date "20060102150405" }}-self-registration"
                 optional: true
           {{- end }}

--- a/charts/testkube-runner/templates/deployment.yaml
+++ b/charts/testkube-runner/templates/deployment.yaml
@@ -323,6 +323,8 @@ spec:
           {{- if .Values.runner.register.token }}
             - name: TESTKUBE_PRO_AGENT_REGISTRATION_TOKEN
               value: "{{ .Values.runner.register.token }}"
+            - name: RUNNER_NAME
+              value: "{{ include "testkube-runner.fullname" . }}-{{ now | date "20060102150405" }}"
             - name: ENABLE_SECRETS_ENDPOINT
               value: "true"
             - name: SELF_REGISTRATION_SECRET

--- a/charts/testkube-runner/templates/deployment.yaml
+++ b/charts/testkube-runner/templates/deployment.yaml
@@ -180,10 +180,12 @@ spec:
                   name: "{{ .Values.runner.secretRef.name }}"
                   key: "{{ .Values.runner.secretRef.secretKey }}"
             {{- else }}
+            {{- if not .Values.runner.register.token }}
             - name: "TESTKUBE_PRO_AGENT_ID"
               value: "{{ .Values.runner.id }}"
             - name: "TESTKUBE_PRO_API_KEY"
               value: "{{ .Values.runner.secret }}"
+            {{- end }}
             - name: "TESTKUBE_PRO_ORG_ID"
               value: "{{ .Values.runner.orgId }}"
             {{- end }}
@@ -316,3 +318,25 @@ spec:
             {{- if .Values.pod.extraEnvVars }}
             {{ toYaml .Values.pod.extraEnvVars | nindent 12 | trim }}
             {{- end }}
+
+            # Self registration
+          {{- if .Values.runner.register.token }}
+            - name: TESTKUBE_PRO_API_URL
+              value: "{{ .Values.runner.register.url }}"
+            - name: TESTKUBE_PRO_AGENT_REGISTRATION_TOKEN
+              value: "{{ .Values.runner.register.token }}"
+            - name: TESTKUBE_PRO_ENV_ID
+              value: "{{ .Values.runner.envId }}"
+            - name: ENABLE_SECRETS_ENDPOINT
+              value: "true"
+            - name: SELF_REGISTRATION_SECRET
+              value: "self-registration"
+            - name: SECRET_CREATION_PREFIX
+              value: "testkube-"
+            - name: FLOATING_RUNNER
+              value: "{{ .Values.runner.register.floating }}"
+          envFrom:
+            - secretRef:
+                name: testkube-self-registration
+                optional: true
+          {{- end }}

--- a/charts/testkube-runner/templates/deployment.yaml
+++ b/charts/testkube-runner/templates/deployment.yaml
@@ -321,8 +321,6 @@ spec:
 
             # Self registration
           {{- if .Values.runner.register.token }}
-            - name: TESTKUBE_PRO_API_URL
-              value: "{{ .Values.runner.register.url }}"
             - name: TESTKUBE_PRO_AGENT_REGISTRATION_TOKEN
               value: "{{ .Values.runner.register.token }}"
             - name: TESTKUBE_PRO_ENV_ID

--- a/charts/testkube-runner/values.yaml
+++ b/charts/testkube-runner/values.yaml
@@ -30,7 +30,6 @@ runner:
     secretKey: "secret"
   ## Self-registration using API token
   register:
-    url: "api.testkube.io:443"
     ## Control Plane API token
     token: ""
     ## Whether to register as a Floating runner

--- a/charts/testkube-runner/values.yaml
+++ b/charts/testkube-runner/values.yaml
@@ -14,8 +14,6 @@ runner:
   id: ""
   ## Organization ID
   orgId: ""
-  ## Environment ID
-  envId: ""
   ## Secret Key
   secret: ""
   ## Retrieve credential information from an existing secret

--- a/charts/testkube-runner/values.yaml
+++ b/charts/testkube-runner/values.yaml
@@ -14,6 +14,8 @@ runner:
   id: ""
   ## Organization ID
   orgId: ""
+  ## Environment ID
+  envId: ""
   ## Secret Key
   secret: ""
   ## Retrieve credential information from an existing secret
@@ -26,6 +28,13 @@ runner:
     orgIdKey: "orgId"
     ## Key for the Secret Key
     secretKey: "secret"
+  ## Self-registration using API token
+  register:
+    url: "api.testkube.io:443"
+    ## Control Plane API token
+    token: ""
+    ## Whether to register as a Floating runner
+    floating: false
 
 ## Global TestWorkflowTemplate that will be automatically included for all executions
 globalTemplate:


### PR DESCRIPTION
Add extra values that allow for the creation and registering of a runner in a single `helm install` step. Using the new values it would be possible using a command similar to:

```
helm install my-testkube-runner kubeshop/testkube-runner \
    --set runner.register.token="tkcapi_5f4dcc3b5aa765d61d8327deb882" \
    --set runner.orgId="tkcorg_97c6968d0a9e7880"
```

Requires changes in https://github.com/kubeshop/testkube/pull/6410 otherwise nothing will happen.