### PR TITLE
feat: push runner to oci registry

### DIFF
--- a/.github/workflows/helm-releaser-testkube-runner-chart-only.yaml
+++ b/.github/workflows/helm-releaser-testkube-runner-chart-only.yaml
@@ -3,20 +3,19 @@ name: Releasing Testkube runner helm chart
 concurrency: develop_cluster
 
 on:
-#  workflow_dispatch:
+  workflow_dispatch:
 
   push:
-#    paths:
-#      - "charts/testkube-runner/**"
-#      - "!charts/testkube-runner/Chart.yaml"
+    paths:
+      - "charts/testkube-runner/**"
+      - "!charts/testkube-runner/Chart.yaml"
     branches:
       - main
-      - feat/push-runner-to-oci
 
 jobs:
   release_charts:
     runs-on: ubuntu-latest
-#    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout
@@ -43,11 +42,11 @@ jobs:
         with:
           cmd: yq '.version' charts/testkube-runner/Chart.yaml
 
-#      - name: Update runner Chart.yaml
-#        run: |
-#          cd ./scripts
-#          chmod +x runner_chart_releaser.sh
-#          ./runner_chart_releaser.sh --runner-chart true
+      - name: Update runner Chart.yaml
+        run: |
+          cd ./scripts
+          chmod +x runner_chart_releaser.sh
+          ./runner_chart_releaser.sh --runner-chart true
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -105,103 +104,94 @@ jobs:
           git push origin gh-pages --force-with-lease=index:${current_commit_id}
   
 
-  #      - name: Run chart-releaser
-#        uses: helm/chart-releaser-action@v1.6.0
-#        with:
-#          charts_dir: charts
-#          mark_as_latest: true
-#        env:
-#          CR_TOKEN: "${{ secrets.CI_BOT_TOKEN }}"
-#          CR_SKIP_EXISTING: true
+  notify_slack_if_helm_chart_release_fails:
+    runs-on: ubuntu-latest
+    needs: release_charts
+    if: always() && (needs.release_charts.result == 'failure')
+    steps:
+      - name: Slack Notification if Helm Release action failed
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.release_charts.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Helm Chart release action failed :boom:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"
 
-#  notify_slack_if_helm_chart_release_fails:
-#    runs-on: ubuntu-latest
-#    needs: release_charts
-#    if: always() && (needs.release_charts.result == 'failure')
-#    steps:
-#      - name: Slack Notification if Helm Release action failed
-#        uses: rtCamp/action-slack-notify@v2
-#        env:
-#          SLACK_CHANNEL: testkube-logs
-#          SLACK_COLOR: ${{ needs.release_charts.result }} # or a specific color like 'good' or '#ff00ff'
-#          SLACK_ICON: https://github.com/rtCamp.png?size=48
-#          SLACK_TITLE: Helm Chart release action failed :boom:!
-#          SLACK_USERNAME: GitHub
-#          SLACK_LINK_NAMES: true
-#          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-#          SLACK_FOOTER: "Kubeshop --> TestKube"
-#
-#  refreshing_gh_pages:
-#    needs: release_charts
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Triggering refresh for GH-pages to make just released charts available
-#        run: |
-#          curl -s --fail --request POST \
-#            --url https://api.github.com/repos/kubeshop/helm-charts/pages/builds \
-#            --header "Authorization: Bearer $USER_TOKEN"
-#        env:
-#          # You must create a personal token with repo access as GitHub does
-#          # not yet support server-to-server page builds.
-#          USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
-#
-#  checking_that_ghpages_updated:
-#    needs: refreshing_gh_pages
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Making sure that they are abvailable now.
-#        run: |
-#          status=""
-#          counter=0
-#          while [[ $status != \"built\" ]]
-#          do
-#              status=$(curl -s \
-#              -H "Accept: application/vnd.github.v3+json" \
-#              https://api.github.com/repos/kubeshop/helm-charts/pages/builds/latest \
-#              --header "Authorization: Bearer $USER_TOKEN" | jq .status)
-#              echo "Checking latest GH pages build status --> $status"
-#              sleep 5
-#
-#              counter=$(expr $counter + 1)
-#              if [[ $status == \"errored\" ]] || [[ $counter == 120 ]]; then
-#                echo "Something went wrong. Please check GH's pages issues."
-#                exit 1
-#              fi
-#          done
-#        env:
-#          # You must create a personal token with repo access as GitHub does
-#          # not yet support server-to-server page builds.
-#          USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
-#
-#  notify_slack_if_release_succeeds:
-#    runs-on: ubuntu-latest
-#    needs: checking_that_ghpages_updated
-#    steps:
-#      - name: Slack Notification if the helm release pipeline succeeded.
-#        uses: rtCamp/action-slack-notify@v2
-#        env:
-#          SLACK_CHANNEL: testkube-logs
-#          SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
-#          SLACK_ICON: https://github.com/rtCamp.png?size=48
-#          SLACK_TITLE: Helm chart release succeed and GH pages got updated :party_blob:!
-#          SLACK_USERNAME: GitHub
-#          SLACK_LINK_NAMES: true
-#          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-#          SLACK_FOOTER: "Kubeshop --> TestKube"
-#
-#  notify_slack_if_gh_pages_update_failed:
-#    runs-on: ubuntu-latest
-#    needs: checking_that_ghpages_updated
-#    if: always() && (needs.checking_that_ghpages_updated.result == 'failure')
-#    steps:
-#      - name: Slack Notification if the helm release GH Pages failed.
-#        uses: rtCamp/action-slack-notify@v2
-#        env:
-#          SLACK_CHANNEL: testkube-logs
-#          SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
-#          SLACK_ICON: https://github.com/rtCamp.png?size=48
-#          SLACK_TITLE: Helm chart release failed on GH pages update! :boom:!
-#          SLACK_USERNAME: GitHub
-#          SLACK_LINK_NAMES: true
-#          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-#          SLACK_FOOTER: "Kubeshop --> TestKube"
+  refreshing_gh_pages:
+    needs: release_charts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Triggering refresh for GH-pages to make just released charts available
+        run: |
+          curl -s --fail --request POST \
+            --url https://api.github.com/repos/kubeshop/helm-charts/pages/builds \
+            --header "Authorization: Bearer $USER_TOKEN"
+        env:
+          # You must create a personal token with repo access as GitHub does
+          # not yet support server-to-server page builds.
+          USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+
+  checking_that_ghpages_updated:
+    needs: refreshing_gh_pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Making sure that they are abvailable now.
+        run: |
+          status=""
+          counter=0
+          while [[ $status != \"built\" ]]
+          do
+              status=$(curl -s \
+              -H "Accept: application/vnd.github.v3+json" \
+              https://api.github.com/repos/kubeshop/helm-charts/pages/builds/latest \
+              --header "Authorization: Bearer $USER_TOKEN" | jq .status)
+              echo "Checking latest GH pages build status --> $status"
+              sleep 5
+
+              counter=$(expr $counter + 1)
+              if [[ $status == \"errored\" ]] || [[ $counter == 120 ]]; then
+                echo "Something went wrong. Please check GH's pages issues."
+                exit 1
+              fi
+          done
+        env:
+          # You must create a personal token with repo access as GitHub does
+          # not yet support server-to-server page builds.
+          USER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+
+  notify_slack_if_release_succeeds:
+    runs-on: ubuntu-latest
+    needs: checking_that_ghpages_updated
+    steps:
+      - name: Slack Notification if the helm release pipeline succeeded.
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Helm chart release succeed and GH pages got updated :party_blob:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"
+
+  notify_slack_if_gh_pages_update_failed:
+    runs-on: ubuntu-latest
+    needs: checking_that_ghpages_updated
+    if: always() && (needs.checking_that_ghpages_updated.result == 'failure')
+    steps:
+      - name: Slack Notification if the helm release GH Pages failed.
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: testkube-logs
+          SLACK_COLOR: ${{ needs.checking_that_ghpages_updated.result }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_TITLE: Helm chart release failed on GH pages update! :boom:!
+          SLACK_USERNAME: GitHub
+          SLACK_LINK_NAMES: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: "Kubeshop --> TestKube"


### PR DESCRIPTION
## Pull request description 
Push Testkube Runner chart to OCI registry:
`helm pull oci://registry-1.docker.io/kubeshop/testkube-runner --version 2.1.163`


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-