### PR TITLE
feat: [TKC-4062] add listener option to chart

### DIFF
--- a/charts/testkube-runner/templates/deployment.yaml
+++ b/charts/testkube-runner/templates/deployment.yaml
@@ -289,7 +289,7 @@ spec:
             - name: "ENABLE_K8S_EVENTS"
               value: "false"
             - name: "DISABLE_TEST_TRIGGERS"
-              value: "true"
+              value: "{{ if .Values.listener.enabled }}false{{ else }}true{{ end }}"
             - name: "DISABLE_WEBHOOKS"
               value: "true"
             - name: "DISABLE_DEPRECATED_TESTS"

--- a/charts/testkube-runner/templates/role.yaml
+++ b/charts/testkube-runner/templates/role.yaml
@@ -153,3 +153,105 @@ rules:
 {{- end }}
 {{- end }}
 {{- end }}
+
+---
+
+# Allow Agent to access leases for triggers functionality
+{{- if and .Values.pod.serviceAccount.autoCreate .Values.listener.enabled }}
+apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name: "triggers-lease-access-{{ .Release.Name }}"
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- if .Values.global.labels }}
+    {{- toYaml .Values.global.labels | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.global.annotations }}
+    {{- toYaml .Values.global.annotations | nindent 4 }}
+    {{- end }}
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "create", "update"]
+{{- end }}
+
+---
+
+# Allow Agent to watch resources for triggers functionality
+{{- if and .Values.pod.serviceAccount.autoCreate .Values.listener.enabled }}
+apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: "watchers-role-{{ .Release.Name }}"
+  labels:
+    {{- if .Values.global.labels }}
+    {{- toYaml .Values.global.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.global.annotations}}
+  annotations:
+    {{- toYaml .Values.global.annotations | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - events
+      - namespaces
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "apps"
+    resources:
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "networking.k8s.io"
+      - "extensions"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "tests.testkube.io"
+    resources:
+      - testtriggers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "executor.testkube.io"
+    resources:
+      - webhooks
+      - webhooktemplates
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "testworkflows.testkube.io"
+    resources:
+      - testworkflows
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}
+
+---
+
+

--- a/charts/testkube-runner/templates/rolebinding.yaml
+++ b/charts/testkube-runner/templates/rolebinding.yaml
@@ -29,6 +29,37 @@ roleRef:
 
 ---
 
+# Apply triggers lease access role
+{{- if and .Values.pod.serviceAccount.autoCreate .Values.listener.enabled }}
+apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
+kind: RoleBinding
+metadata:
+  name: "triggers-lease-access-rb-{{ .Release.Name }}"
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- if .Values.global.labels }}
+    {{- toYaml .Values.global.labels | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.global.annotations }}
+    {{- toYaml .Values.global.annotations | nindent 4 }}
+    {{- end }}
+subjects:
+- kind: ServiceAccount
+  namespace: "{{ .Release.Namespace }}"
+  {{- if .Values.pod.serviceAccount.name }}
+  name: "{{ .Values.pod.serviceAccount.name }}"
+  {{- else }}
+  name: "agent-sa-{{ .Release.Name }}"
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "triggers-lease-access-{{ .Release.Name }}"
+{{- end }}
+
+---
+
 # Apply execution in default namespace role
 apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
@@ -167,4 +198,34 @@ roleRef:
   name: "exec-role-{{ .Release.Name }}"
 {{- end }}
 {{- end }}
+{{- end }}
+
+---
+
+# Apply watchers cluster role for triggers functionality
+{{- if and .Values.pod.serviceAccount.autoCreate .Values.listener.enabled }}
+apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: "watchers-role-rb-{{ .Release.Name }}"
+  labels:
+    {{- if .Values.global.labels }}
+    {{- toYaml .Values.global.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.global.annotations}}
+  annotations:
+    {{- toYaml .Values.global.annotations | nindent 4 }}
+  {{- end }}
+subjects:
+- kind: ServiceAccount
+  namespace: "{{ .Release.Namespace }}"
+  {{- if .Values.pod.serviceAccount.name }}
+  name: "{{ .Values.pod.serviceAccount.name }}"
+  {{- else }}
+  name: "agent-sa-{{ .Release.Name }}"
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "watchers-role-{{ .Release.Name }}"
 {{- end }}

--- a/charts/testkube-runner/values.yaml
+++ b/charts/testkube-runner/values.yaml
@@ -44,6 +44,11 @@ globalTemplate:
   #     imagePullSecrets:
   #     - name: regcred
 
+## Listener configuration for triggers
+listener:
+  ## Enable listener functionality
+  enabled: false
+
 execution:
   default:
     ## Default namespace to run executions


### PR DESCRIPTION
## Pull request description 

- 
- Adds listener.enabled configuration option to values.yaml
- Sets DISABLE_TRIGGERS=false when listener is enabled
- Creates RBAC role and rolebinding for lease access in coordination.k8s.io API group
- Only creates RBAC resources when both pod.serviceAccount.autoCreate and listener.enabled are true

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-