### PR TITLE
feat: [TKC-4120] allow fetching triggers from cp

### DIFF
--- a/charts/testkube-runner/templates/deployment.yaml
+++ b/charts/testkube-runner/templates/deployment.yaml
@@ -317,6 +317,12 @@ spec:
               value: "true"
             - name: "FEATURE_NEW_ARCHITECTURE"
               value: "true"
+            {{- if .Values.listener.enabled }}
+            - name: "TEST_TRIGGER_CONTROL_PLANE"
+              value: "true"
+            - name: "FEATURE_CLOUD_STORAGE"
+              value: "true"
+            {{- end }}
             # - name: "FEATURE_CLOUD_STORAGE"
             #   value: "true"
 


### PR DESCRIPTION
## Pull request description 

This changes make listener agent to fetch triggers from control-plane, which will take it from SuperAgent.

This is not breaking change, since `listener.enabled=true` was introduced by me for listener capability, and is not used.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-