### PR TITLE
fix: allow setting pathtype for testkube cli ingress

### DIFF
--- a/charts/testkube-api/templates/cli-ingress.yaml
+++ b/charts/testkube-api/templates/cli-ingress.yaml
@@ -43,7 +43,7 @@ spec:
       http:
         paths:
           - path: {{ $.Values.cliIngress.path }}
-            pathType: Prefix
+            pathType: {{ default "Prefix" $.Values.cliIngress.pathType }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.Version }}
               service:

--- a/charts/testkube-api/values.yaml
+++ b/charts/testkube-api/values.yaml
@@ -753,6 +753,8 @@ cliIngress:
   annotations: {}
   ## The Path to Nginx.
   path: /results/(v\d/.*)
+  ## The PathType to Nginx.
+  pathType: Prefix
   ## Hostnames must be provided if Ingress is enabled.
   hosts: []
   # - testkube.example.com


### PR DESCRIPTION
Allow to modify `pathType` for CLI ingress.

Fix https://github.com/kubeshop/helm-charts/issues/1052