### PR TITLE
fix sed command in index-update workflow not properly replacing the tag for OCI registries

### DIFF
--- a/.github/workflows/index-update.yaml
+++ b/.github/workflows/index-update.yaml
@@ -38,7 +38,7 @@ jobs:
           # Rebuild index
           helm repo index --url oci://us-east1-docker.pkg.dev/testkube-cloud-372110/testkube --merge index.yaml ./download
           # Replace .tgz in URL with OCI tag
-          sed -i "s|oci://us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/testkube-$chart_version.tgz|oci://us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/testkube:$chart_version|" ./download/index.yaml
+          sed -i 's|oci://us-east1-docker\.pkg\.dev/testkube-cloud-372110/testkube/testkube-\([0-9a-z._-]\+\)\.tgz|oci://us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/testkube:\1|g' ./download/index.yaml
 
           ## Update index for "testkube-runner" chart
           # Download published asset
@@ -46,7 +46,7 @@ jobs:
           # Rebuild index
           helm repo index --url oci://us-east1-docker.pkg.dev/testkube-cloud-372110/testkube --merge index.yaml ./download
           # Replace .tgz in URL with OCI tag
-          sed -i "s|oci://us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/testkube-runner-$chart_version.tgz|oci://us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/testkube-runner:$chart_version|" ./download/index.yaml
+          sed -i 's|oci://us-east1-docker\.pkg\.dev/testkube-cloud-372110/testkube/testkube-runner-\([0-9a-z._-]\+\)\.tgz|oci://us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/testkube-runner:\1|g' ./download/index.yaml
 
 
           # Check index integrity


### PR DESCRIPTION
## Pull request description 

Fixes the index update workflow to correctly format OCI URLs for all chart versions, not just the one being added.

### Problem

When helm repo index merges entries, it creates malformed OCI URLs. The old sed command had issues and wasn't properly updating the indexes.

Example of malformed URL:
```
oci://us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/testkube-2.4.0.tgz
```

Should be:
```
oci://us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/testkube:2.4.0
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-