### PR TITLE
fix: correct 'succesfully' typo in kusk-gateway helm NOTES

### DIFF
--- a/charts/kusk-gateway/templates/NOTES.txt
+++ b/charts/kusk-gateway/templates/NOTES.txt
@@ -1,3 +1,3 @@
-Kusk Gateway Manager was succesfully deployed.
+Kusk Gateway Manager was successfully deployed.
 
 Deploy Envoy Fleet Helm chart to create the gateway and then deploy API or StaticRoute custom resources to expose your applications endpoints.


### PR DESCRIPTION
## Pull request description

Fixes a user-facing 'succesfully' -> 'successfully' typo in the `kusk-gateway` Helm `NOTES.txt` post-install output.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

- None.

## Changes

- `charts/kusk-gateway/templates/NOTES.txt`: 'succesfully' -> 'successfully'.

## Fixes

- Cosmetic typo in post-install NOTES output users see after `helm install`.
