### PR TITLE
fix(testkube-runner): bump appVersion for CVE-patched runner images

### DIFF
--- a/charts/testkube-runner/Chart.yaml
+++ b/charts/testkube-runner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: testkube-runner
 description: A Helm chart for the Testkube's Runner Agent
 type: application
-version: 2.3.1
-appVersion: 2.3.0
+version: 2.3.2
+appVersion: 2.11.1
 dependencies:
 - name: global
   version: 0.1.3


### PR DESCRIPTION
## Summary

Bumps the `testkube-runner` chart so the default image tags point to the CVE-patched runner images shipped with Testkube 2.11.1 (includes [kubeshop/testkube#7910](https://github.com/kubeshop/testkube/pull/7910)).

### Changes
- `appVersion`: `2.3.0` → `2.11.1`
- chart `version`: `2.3.1` → `2.3.2`

This updates the default tags for:
- `kubeshop/testkube-api-server` — `apk upgrade` clears openssl CRITICAL CVE-2026-31789
- `kubeshop/testkube-tw-toolkit` — same OS patching
- `kubeshop/testkube-tw-init` — rebuilt on busybox `1.37.0-musl` (clears CVE-2022-48174)

### Note
The `2.11.1` images must be published before this merges — coordinate with the next Testkube release cut that includes kubeshop/testkube#7910.

## Test plan
- [x] Patched images validated on a local Kind cluster (runner connects to control plane, executes TestWorkflows, artifacts stored)
- [ ] Confirm `2.11.1` images exist on Docker Hub before merging

Made with [Cursor](https://cursor.com)